### PR TITLE
Пример speech-to-text на Python

### DIFF
--- a/ru/speechkit/stt/request.md
+++ b/ru/speechkit/stt/request.md
@@ -99,7 +99,6 @@ params = "&".join([
 
 url = urllib.request.Request("https://stt.api.cloud.yandex.net/speech/v1/stt:recognize/?%s" % params, data=data)
 url.add_header("Authorization", "Bearer %s" % IAM_TOKEN)
-url.add_header("Transfer-Encoding", "chunked")
 
 responseData = urllib.request.urlopen(url).read().decode('UTF-8')
 decodedData = json.loads(responseData)


### PR DESCRIPTION
При установленном параметре "Transfer-encoding" запросы не уходили. Данный параметр характерен только для HTTP1.1, вторая версия HTTP его не поддерживает, сервис Яндекса выдавал "400 Bad Request" (ровно как и другой сервис на HTTP2).
На всякий случай оставляю референс: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding