### PR TITLE
Interpolation has been deprecated since v0.12.*

### DIFF
--- a/en/solutions/infrastructure-management/terraform-quickstart.md
+++ b/en/solutions/infrastructure-management/terraform-quickstart.md
@@ -54,7 +54,7 @@ The VMs will have a different number of cores and amount of RAM: 1 core and 2 GB
 
 Resource configurations are specified immediately after the provider's configuration:
 
-```
+```hcl
 provider "yandex" {
   token     = "OAuth_token"
   cloud_id  = "cloud-id"
@@ -77,7 +77,7 @@ resource "yandex_compute_instance" "vm-1" {
   }
 
   network_interface {
-    subnet_id = "${yandex_vpc_subnet.subnet-1.id}"
+    subnet_id = yandex_vpc_subnet.subnet-1.id
     nat       = true
   }
 
@@ -101,7 +101,7 @@ resource "yandex_compute_instance" "vm-2" {
   }
 
   network_interface {
-    subnet_id = "${yandex_vpc_subnet.subnet-1.id}"
+    subnet_id = yandex_vpc_subnet.subnet-1.id
     nat       = true
   }
 
@@ -117,25 +117,25 @@ resource "yandex_vpc_network" "network-1" {
 resource "yandex_vpc_subnet" "subnet-1" {
   name           = "subnet1"
   zone           = "ru-central1-a"
-  network_id     = "${yandex_vpc_network.network-1.id}"
+  network_id     = yandex_vpc_network.network-1.id
   v4_cidr_blocks = ["192.168.10.0/24"]
 }
 
 output "internal_ip_address_vm_1" {
-  value = "${yandex_compute_instance.vm-1.network_interface.0.ip_address}"
+  value = yandex_compute_instance.vm-1.network_interface.0.ip_address
 }
 
 output "internal_ip_address_vm_2" {
-  value = "${yandex_compute_instance.vm-2.network_interface.0.ip_address}"
+  value = yandex_compute_instance.vm-2.network_interface.0.ip_address
 }
 
 
 output "external_ip_address_vm_1" {
-  value = "${yandex_compute_instance.vm-1.network_interface.0.nat_ip_address}"
+  value = yandex_compute_instance.vm-1.network_interface.0.nat_ip_address
 }
 
 output "external_ip_address_vm_2" {
-  value = "${yandex_compute_instance.vm-2.network_interface.0.nat_ip_address}"
+  value = yandex_compute_instance.vm-2.network_interface.0.nat_ip_address
 }
 ```
 
@@ -172,4 +172,3 @@ If there are no errors in the configuration, run the `terraform apply` command. 
 ## Delete resources {#delete-resources}
 
 To delete all resources created via Terraform, run the `terraform destroy` command. After the command has been executed, the terminal will display a list of resources that will be deleted. Type `yes` to confirm them and press Enter.
-

--- a/ru/solutions/infrastructure-management/terraform-quickstart.md
+++ b/ru/solutions/infrastructure-management/terraform-quickstart.md
@@ -54,7 +54,7 @@
 
 Конфигурации ресурсов задаются сразу после конфигурации провайдера:
 
-```
+```hcl
 provider "yandex" {
   token     = "OAuth_token"
   cloud_id  = "cloud-id"
@@ -77,7 +77,7 @@ resource "yandex_compute_instance" "vm-1" {
   }
 
   network_interface {
-    subnet_id = "${yandex_vpc_subnet.subnet-1.id}"
+    subnet_id = yandex_vpc_subnet.subnet-1.id
     nat       = true
   }
 
@@ -101,7 +101,7 @@ resource "yandex_compute_instance" "vm-2" {
   }
 
   network_interface {
-    subnet_id = "${yandex_vpc_subnet.subnet-1.id}"
+    subnet_id = yandex_vpc_subnet.subnet-1.id
     nat       = true
   }
 
@@ -117,25 +117,25 @@ resource "yandex_vpc_network" "network-1" {
 resource "yandex_vpc_subnet" "subnet-1" {
   name           = "subnet1"
   zone           = "ru-central1-a"
-  network_id     = "${yandex_vpc_network.network-1.id}"
+  network_id     = yandex_vpc_network.network-1.id
   v4_cidr_blocks = ["192.168.10.0/24"]
 }
 
 output "internal_ip_address_vm_1" {
-  value = "${yandex_compute_instance.vm-1.network_interface.0.ip_address}"
+  value = yandex_compute_instance.vm-1.network_interface.0.ip_address
 }
 
 output "internal_ip_address_vm_2" {
-  value = "${yandex_compute_instance.vm-2.network_interface.0.ip_address}"
+  value = yandex_compute_instance.vm-2.network_interface.0.ip_address
 }
 
 
 output "external_ip_address_vm_1" {
-  value = "${yandex_compute_instance.vm-1.network_interface.0.nat_ip_address}"
+  value = yandex_compute_instance.vm-1.network_interface.0.nat_ip_address
 }
 
 output "external_ip_address_vm_2" {
-  value = "${yandex_compute_instance.vm-2.network_interface.0.nat_ip_address}"
+  value = yandex_compute_instance.vm-2.network_interface.0.nat_ip_address
 }
 ```
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
- I removed interpolation as it's been deprecated since terraform v0.12.*
- I was editing the file from the web UI, and GitHub replaced the end of it with a different EOF symbol, so the last line has been changed.
