### PR TITLE
Change typo in UpdateHosts section

### DIFF
--- a/ru/managed-postgresql/operations/hosts.md
+++ b/ru/managed-postgresql/operations/hosts.md
@@ -158,7 +158,7 @@
   
 - API
   
-  Удалить хост можно с помощью метода [deleteHosts](../api-ref/Cluster/deleteHosts.md).
+  Удалить хост можно с помощью метода [updateHosts](../api-ref/Cluster/updateHosts.md).
   
 {% endlist %}
 


### PR DESCRIPTION
Updated hosts api-ref link was referring to deleteHosts.md, which was a typo I guess.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru
