### PR TITLE
Fix region name for s3 backend

### DIFF
--- a/ru/solutions/infrastructure-management/terraform-state-storage.md
+++ b/ru/solutions/infrastructure-management/terraform-state-storage.md
@@ -83,7 +83,7 @@ terraform {
   backend "s3" {
     endpoint   = "storage.yandexcloud.net"
     bucket     = "<имя бакета>"
-    region     = "us-east-1"
+    region     = "ru-central1"
     key        = "<путь к файлу состояния в бакете>/<имя файла состояния>.tfstate"
     access_key = "<идентификатор статического ключа>"
     secret_key = "<секретный ключ>"
@@ -115,7 +115,7 @@ terraform {
      backend "s3" {
        endpoint   = "storage.yandexcloud.net"
        bucket     = "<имя бакета>"
-       region     = "us-east-1"
+       region     = "ru-central1"
        key        = "<путь к файлу состояния в бакете>/<имя файла состояния>.tfstate"
        access_key = "<идентификатор статического ключа>"
        secret_key = "<секретный ключ>"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru
Description of changes:
https://cloud.yandex.ru/docs/storage/tools/aws-cli
Примечание
Для работы с Yandex Object Storage всегда указывайте регион — ru-central1. Другие значения региона могут привести к ошибке авторизации.
