### PR TITLE
fix: specified passwd_file is not readable.

### DIFF
--- a/ru/storage/tools/s3fs.md
+++ b/ru/storage/tools/s3fs.md
@@ -35,7 +35,7 @@ chmod 600  ~/.passwd-s3fs
 2. Выполните команду вида:
 
     ```
-    s3fs <имя бакета> /mount/<путь к папке> -o passwd_file=~/.passwd-s3fs \
+    s3fs <имя бакета> /mount/<путь к папке> -o passwd_file=$HOME/.passwd-s3fs \
         -o url=http://storage.yandexcloud.net -o use_path_request_style
     ```
 


### PR DESCRIPTION
> The shell expands tildes but only when they are the leading character of a string.

https://github.com/s3fs-fuse/s3fs-fuse/issues/836

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes: replace tilde with `$HOME` variable.
