### PR TITLE
Change “Azure Application Gateway” to “API Gateway”

### DIFF
--- a/en/overview/platform-comparison/gcp.md
+++ b/en/overview/platform-comparison/gcp.md
@@ -3,7 +3,7 @@
 | Google Cloud Platform | {{ yandex-cloud }} |
 | ---- | ---- |
 | AI Platform | [{{ ml-platform-full-name }}](../../datasphere/) |
-| Azure Application Gateway | [{{ api-gw-full-name }}](../../api-gateway/) |
+| API Gateway | [{{ api-gw-full-name }}](../../api-gateway/) |
 | Cloud Dataproc | [{{ dataproc-full-name }}](../../data-proc/) |
 | Cloud Functions | [{{ sf-full-name }}](../../functions/) |
 | Cloud Interconnect | [{{ interconnect-full-name }}](../../vpc/interconnect/) |


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:

- Change “Azure Application Gateway” (obviously not a Google Cloud Platform product) to “API Gateway” (https://cloud.google.com/api-gateway)
