### PR TITLE
Removed broken link

### DIFF
--- a/ru/ydb/docapi/api-ref/index.md
+++ b/ru/ydb/docapi/api-ref/index.md
@@ -23,7 +23,3 @@
 [TransactGetItems](actions/transactGetItems) | Извлекает несколько элементов из таблиц
 [TransactWriteItems](actions/transactWriteItems) | Синхронная операция записи
 [UpdateItem](actions/updateItem) | Обновляет элементы в таблице
-
-
-## Полезные рецепты
-[Уникальность атрибута](../../uniqueConstraint) Как с помощью транзакций обеспечить уникальность атрибута таблицы.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:

https://cloud.yandex.ru/docs/ydb/docapi/api-ref/ — link "Уникальность атрибута" gives 404 eror