### PR TITLE
Fixed unified agent configuration example

### DIFF
--- a/ru/monitoring/operations/unified-agent/pull_prometheus.md
+++ b/ru/monitoring/operations/unified-agent/pull_prometheus.md
@@ -117,12 +117,12 @@
 
         routes:
           - input:
-            plugin: metrics_pull
-            config:
-              url: http://localhost:8000
-              format:
-                prometheus: {}
-              namespace: app
+              plugin: metrics_pull
+              config:
+                url: http://localhost:8000
+                format:
+                  prometheus: {}
+                namespace: app
             channel:
               channel_ref:
                 name: cloud_monitoring


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
config file in example doesn't pass the check with
```
unified_agent --config /etc/yandex/unified_agent/config.yml check-config
```
due to incorrect indentation.