### PR TITLE
Fix registry IAM link

### DIFF
--- a/en/container-registry/operations/authentication.md
+++ b/en/container-registry/operations/authentication.md
@@ -122,7 +122,7 @@ Using a [service account](../../iam/concepts/users/service-accounts.md), your pr
 
 {% endnote %}
 
-1. [Get an IAM token](../../iam/operations/iam-token/create.md).
+1. [Get an IAM token](../../iam/operations/iam-token/create-for-sa.md).
 
 1. Run the command:
 

--- a/ru/container-registry/operations/authentication.md
+++ b/ru/container-registry/operations/authentication.md
@@ -122,7 +122,7 @@ $ docker login \
 
 {% endnote %}
 
-1. [Получите IAM-токен](../../iam/operations/iam-token/create.md).
+1. [Получите IAM-токен](../../iam/operations/iam-token/create-for-sa.md).
 1. Выполните команду:
 
     ```


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes: fix IAM token creation link for service accounts.