### PR TITLE
k8s rbac API update

### DIFF
--- a/ru/managed-kubernetes/operations/create-static-conf.md
+++ b/ru/managed-kubernetes/operations/create-static-conf.md
@@ -118,7 +118,7 @@ __system: {"dislikeVariants":["Нет ответа на мой вопрос","Р
       name: admin-user
       namespace: kube-system
     ---
-    apiVersion: rbac.authorization.k8s.io/v1beta1
+    apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
       name: admin-user


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
In yaml fie used old API version (rbac.authorization.k8s.io/v1beta1)
Now apiVersion rbac.authorization.k8s.io/v1 is primary recommended