### PR TITLE
Исправлена невалидная ссылка на документацию Kubernetes

### DIFF
--- a/ru/managed-kubernetes/operations/create-static-conf.md
+++ b/ru/managed-kubernetes/operations/create-static-conf.md
@@ -109,7 +109,7 @@ __system: {"dislikeVariants":["Нет ответа на мой вопрос","Р
 
 1. Сохраните следующую спецификацию для создания объекта `ServiceAccount` в YAML-файл с названием `sa.yaml`.
 
-    Подробную спецификацию объекта `ServiceAccount` читайте в [документации {{ k8s }}](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#serviceaccount-v1-core).  
+    Подробную спецификацию объекта `ServiceAccount` читайте в [документации {{ k8s }}](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/service-account-v1/).  
 
     ```
     apiVersion: v1


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
Исправлена невалидная ссылка на документацию Kubernetes со спецификацией ServiceAccount
