### PR TITLE
Update listobjects IsTruncated element description

### DIFF
--- a/en/storage/s3/api-ref/bucket/listobjects.md
+++ b/en/storage/s3/api-ref/bucket/listobjects.md
@@ -91,7 +91,7 @@ A successful response contains additional data in XML format with the schema des
 | Element | Description |
 | ----- | ----- |
 | `ListBucketResult` | Root element. |
-| `IsTruncated` | Flag indicating whether all results are returned in the response.<br/><br/>`True`: All.`False`: Not all.<br/><br/>Path: `/ListBucketResult/IsTruncated`. |
+| `IsTruncated` | Flag indicating whether all results are returned in the response.<br/><br/>`True`: Not all.`False`: All.<br/><br/>Path: `/ListBucketResult/IsTruncated`. |
 | `Contents` | Object description.<br/><br/>The response contains as many `Contents` elements as there are keys that meet the request criteria.<br/><br/>Path: `/ListBucketResult/Contents`. |
 | `ETag` | MD5 hash of the object. No metadata is included in the hash value calculation.<br/><br/>Path: `/ListBucketResult/Contents/ETag`. |
 | `Key` | Object key.<br/><br/>Path: `/ListBucketResult/Contents/Key`. |
@@ -182,7 +182,7 @@ A successful response contains additional data in XML format with the schema des
 | Element | Description |
 | ----- | ----- |
 | `ListBucketResult` | Root element. |
-| `IsTruncated` | Flag indicating whether all results are returned in the response.<br/><br/>`True`: All.`False`: Not all.<br/><br/>Path: `/ListBucketResult/IsTruncated`. |
+| `IsTruncated` | Flag indicating whether all results are returned in the response.<br/><br/>`True`: Not all.`False`: All.<br/><br/>Path: `/ListBucketResult/IsTruncated`. |
 | `Marker` | Value of the `marker` query parameter.<br/><br/>Path: `/ListBucketResult/Marker`. |
 | `NextMarker` | Value to insert in the `marker` query parameter to get the next part of the list if the entire list does not fit in the current response.<br/><br/>Path: `/ListBucketResult/NextMarker`. |
 | `Contents` | Object description.<br/><br/>The response contains as many `Contents` elements as there are keys that meet the request criteria.<br/><br/>Path: `/ListBucketResult/Contents`. |

--- a/ru/storage/s3/api-ref/bucket/listobjects.md
+++ b/ru/storage/s3/api-ref/bucket/listobjects.md
@@ -89,7 +89,7 @@ GET /{bucket}?list-type=2&continuation-token=ContinuationToken&delimiter=Delimit
 Элемент | Описание
 ----- | -----
 `ListBucketResult` | Корневой элемент.
-`IsTruncated` | Флаг, показывающий все ли результаты возвращены в этом ответе.<br/><br/>`True` — все. `False` — не все.<br/><br/>Путь: `/ListBucketResult/IsTruncated`.
+`IsTruncated` | Флаг, показывающий все ли результаты возвращены в этом ответе.<br/><br/>`True` — не все. `False` — все.<br/><br/>Путь: `/ListBucketResult/IsTruncated`.
 `Contents` | Описание объекта.<br/><br/>Ответ будет содержать столько элементов `Contents`, сколько ключей попало под условия запроса.<br/><br/>Путь: `/ListBucketResult/Contents`.
 `ETag` | MD5-хэш объекта. Метаданные в расчете хэша не участвуют.<br/><br/>Путь: `/ListBucketResult/Contents/ETag`.
 `Key` | Ключ объекта.<br/><br/>Путь: `/ListBucketResult/Contents/Key`.
@@ -179,7 +179,7 @@ GET /{bucket}?delimiter=Delimiter&encoding-type=EncodingType&marker=Marker&max-k
 Элемент | Описание
 ----- | -----
 `ListBucketResult` | Корневой элемент.
-`IsTruncated` | Флаг, показывающий все ли результаты возвращены в этом ответе.<br/><br/>`True` — все. `False` — не все.<br/><br/>Путь: `/ListBucketResult/IsTruncated`.
+`IsTruncated` | Флаг, показывающий все ли результаты возвращены в этом ответе.<br/><br/>`True` — не все. `False` — все.<br/><br/>Путь: `/ListBucketResult/IsTruncated`.
 `Marker` | Значение query-параметра `marker`.<br/><br/>Путь: `/ListBucketResult/Marker`.
 `NextMarker` | Значение, которое надо подставить в query-параметр `marker` для получения следующей части списка, если весь список не поместился в текущий ответ.<br/><br/>Путь: `/ListBucketResult/NextMarker`.
 `Contents` | Описание объекта.<br/><br/>Ответ будет содержать столько элементов `Contents`, сколько ключей попало под условия запроса.<br/><br/>Путь: `/ListBucketResult/Contents`.


### PR DESCRIPTION
S3, справочник API, Bucket, listObjects:
В подглавах «Схема данных» для элемента «IsTruncated»
было перепутано описание значений True и False.
И в английской и в русской версии.
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
Path /ListBucketResult/IsTruncated.
Fixed the description of element values True-False