### PR TITLE
add link to Azure AD to other identity providers

### DIFF
--- a/en/organization/add-federation.md
+++ b/en/organization/add-federation.md
@@ -20,6 +20,7 @@ You can set up identity federations for different identity providers:
 
 * [Active Directory](operations/federations/integration-adfs.md).
 * [Google Workspace](operations/federations/integration-gworkspace.md).
+* [Azure Active Directory](operations/federations/integration-azure.md).
 * [Other SAML-compatible identity providers](operations/federations/integration-common.md).
 
 ## Authenticating in a federation {#saml-authentication}

--- a/ru/organization/add-federation.md
+++ b/ru/organization/add-federation.md
@@ -20,6 +20,7 @@
 
 * [Active Directory](operations/federations/integration-adfs.md).
 * [Google Workspace](operations/federations/integration-gworkspace.md).
+* [Azure Active Directory](operations/federations/integration-azure.md).
 * [Другие SAML-совместимые поставщики удостоверений](operations/federations/integration-common.md).
 
 ## Как происходит аутентификация в федерации {#saml-authentication}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:

Отдельная страницу для azure ad была добавлена, а ссылка на неё - нет