### PR TITLE
Опечатка в документации по подключению к БД для примера на GO

### DIFF
--- a/ru/functions/operations/database-connection.md
+++ b/ru/functions/operations/database-connection.md
@@ -116,7 +116,7 @@
 
     // Подключение к БД
     func Handler(ctx context.Context) (*Response, error) {
-        psqlInfo := fmt.Sprintf("host=%s port=%d user=%s "+"password=%s dbname=%s sslmode=require",
+        psqlInfo := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=require",
             host, port, user, getToken(ctx), dbname)
         db, err := sql.Open("postgres", psqlInfo)
         if err != nil {


### PR DESCRIPTION
убрал ни на что не влияющий разрыв в строке 
возможно его не заметили при редактировании

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
Removed a typo in the conn string 