### PR TITLE
Add note about Patroni settings

### DIFF
--- a/ru/data-transfer/operations/prepare.md
+++ b/ru/data-transfer/operations/prepare.md
@@ -230,6 +230,22 @@
 
 {% endlist %}
 
+{% note info %}
+
+Если на вашем источнике настроена репликация через [Patroni](https://github.com/zalando/patroni), то необходимо добавить в его конфигурацию [следующий блок](https://patroni.readthedocs.io/en/latest/SETTINGS.html?highlight=ignore_slots#dynamic-configuration-settings):
+```yaml
+ignore_slots:
+  - database: <имя базы данных, для которой настроен трансфер>
+    name: <имя слота репликации>
+    plugin: wal2json
+    type: logical
+```
+Имя базы данных и имя слота репликации должны совпадать со значениями, указанными в [настройках эндпойнта-источника](../../data-transfer/operations/source-endpoint.md#settings-postgresql). По-умолчанию `имя слота репликации` совпадает с `ID трансфера`.
+
+В противном случае, начало этапа репликации завершится ошибкой: `Warn(Termination): unable to create new pg source: Replication slotID <Ваш ID слота репликации> does not exist`.
+
+{% endnote %}
+
 ### Источник {{ yds-full-name }} {#source-yds}
 
 1. [Создайте поток данных](../../data-streams/operations/manage-streams.md#create-data-stream).

--- a/ru/data-transfer/operations/prepare.md
+++ b/ru/data-transfer/operations/prepare.md
@@ -230,7 +230,7 @@
 
 {% endlist %}
 
-{% note info %}
+{% note warning %}
 
 Если на вашем источнике настроена репликация через [Patroni](https://github.com/zalando/patroni), то необходимо добавить в его конфигурацию [следующий блок](https://patroni.readthedocs.io/en/latest/SETTINGS.html?highlight=ignore_slots#dynamic-configuration-settings):
 ```yaml

--- a/ru/data-transfer/operations/prepare.md
+++ b/ru/data-transfer/operations/prepare.md
@@ -228,23 +228,25 @@
 
     1. Выключите перенос триггеров на стадии активации трансфера и включите его на стадии деактивации (для типов трансфера _{{ dt-type-repl }}_ и _{{ dt-type-copy-repl }}_). Подробнее см. в разделе [Параметры эндпойнта для источника {{ PG }}](source-endpoint.md#settings-postgresql).
 
+    1. Если на источнике настроена репликация через [Patroni](https://github.com/zalando/patroni), добавьте в его конфигурацию [блок ignore_slots](https://patroni.readthedocs.io/en/latest/SETTINGS.html?highlight=ignore_slots#dynamic-configuration-settings):
+
+       ```yaml
+       ignore_slots:
+         - database: <имя базы данных, для которой настроен трансфер>
+           name: <имя слота репликации>
+           plugin: wal2json
+           type: logical
+       ```
+       
+       Имя базы данных и имя слота репликации должны совпадать со значениями, указанными в [настройках эндпойнта для источника](../../data-transfer/operations/source-endpoint.md#settings-postgresql). По-умолчанию `имя слота репликации` совпадает с `ID трансфера`.
+
+       В противном случае начало этапа репликации завершится ошибкой:
+      
+       ```
+       Warn(Termination): unable to create new pg source: Replication slotID <имя слота репликации> does not exist.
+       ```
+
 {% endlist %}
-
-{% note warning %}
-
-Если на вашем источнике настроена репликация через [Patroni](https://github.com/zalando/patroni), то необходимо добавить в его конфигурацию [следующий блок](https://patroni.readthedocs.io/en/latest/SETTINGS.html?highlight=ignore_slots#dynamic-configuration-settings):
-```yaml
-ignore_slots:
-  - database: <имя базы данных, для которой настроен трансфер>
-    name: <имя слота репликации>
-    plugin: wal2json
-    type: logical
-```
-Имя базы данных и имя слота репликации должны совпадать со значениями, указанными в [настройках эндпойнта-источника](../../data-transfer/operations/source-endpoint.md#settings-postgresql). По-умолчанию `имя слота репликации` совпадает с `ID трансфера`.
-
-В противном случае, начало этапа репликации завершится ошибкой: `Warn(Termination): unable to create new pg source: Replication slotID <Ваш ID слота репликации> does not exist`.
-
-{% endnote %}
 
 ### Источник {{ yds-full-name }} {#source-yds}
 


### PR DESCRIPTION
Add note about required Patroni settings if custom installation of source-PostgreSQL managed by Patroni

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
Добавлено небольшое примечание для тех пользователей, кто хочет перенести через DataTransfer PostgreSQL с настроенным Patroni.