### PR TITLE
fix(update) fix ydb update doc error

### DIFF
--- a/ru/ydb/yql/reference/syntax/_includes/update.md
+++ b/ru/ydb/yql/reference/syntax/_includes/update.md
@@ -2,7 +2,6 @@
 sourcePath: core/yql/reference/yql-docs-core-2/syntax/_includes/update.md
 sourcePath: yql/reference/yql-docs-core-2/syntax/_includes/update.md
 ---
-
 # UPDATE
 
 Изменяет данные в таблице. После ключевого слова `SET` указываются столбцы, значение которых необходимо заменить, и сами новые значения. Список строк задается с помощью условия `WHERE`. Если `WHERE` отсутствует, изменения будут применены ко всем строкам таблицы.


### PR DESCRIPTION
эксперименты и ответы в telegramm показали что нельзя давать два update в рамках одной транзакции

исправлено определение UPDATE ON, вставлен дополнительный пример

https://cloud.yandex.ru/docs/ydb/yql/reference/syntax/update

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
