### PR TITLE
Обновил протухшую ссылку на terraform.io/downloads

### DIFF
--- a/ru/_includes/solutions/terraform-install.md
+++ b/ru/_includes/solutions/terraform-install.md
@@ -4,7 +4,7 @@
 
   Используйте один из способов:
 
-  * [Скачайте дистрибутив Terraform](https://www.terraform.io/downloads.html) и установите его согласно [инструкции](https://www.terraform.io/intro/getting-started/install.html).
+  * [Скачайте дистрибутив Terraform](https://www.terraform.io/downloads.html) и установите его согласно [инструкции](https://www.terraform.io/downloads).
   * Установите Terraform с помощью пакетного менеджера [Сhocolatey](https://chocolatey.org/install), используя команду:
 
      ```
@@ -13,13 +13,13 @@
 
 - Linux
 
-  [Скачайте дистрибутив Terraform](https://www.terraform.io/downloads.html) и установите его согласно [инструкции](https://www.terraform.io/intro/getting-started/install.html).
+  [Скачайте дистрибутив Terraform](https://www.terraform.io/downloads.html) и установите его согласно [инструкции](https://www.terraform.io/downloads).
 
 - macOS
 
   Используйте один из способов:
 
-    * [Скачайте дистрибутив Terraform](https://www.terraform.io/downloads.html) и установите его согласно [инструкции](https://www.terraform.io/intro/getting-started/install.html).
+    * [Скачайте дистрибутив Terraform](https://www.terraform.io/downloads.html) и установите его согласно [инструкции](https://www.terraform.io/downloads).
     * Установите Terraform с помощью пакетного менеджера [Homebrew](https://brew.sh), используя команду:
 
       ```


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
Ссылка на инструкцию по установки Terraform изменилась