### PR TITLE
fix(ydb aux)

### DIFF
--- a/ru/ydb/reference/ydb-sdk/example/_includes/auxa/addition.md
+++ b/ru/ydb/reference/ydb-sdk/example/_includes/auxa/addition.md
@@ -1,5 +1,5 @@
 ---
-sourcePath: core/reference/ydb-sdk/example/_includes/aux/addition.md
+sourcePath: core/reference/ydb-sdk/example/_includes/auxa/addition.md
 ---
 {% note info %}
 

--- a/ru/ydb/reference/ydb-sdk/example/_includes/auxa/pragmatablepathprefix.md
+++ b/ru/ydb/reference/ydb-sdk/example/_includes/auxa/pragmatablepathprefix.md
@@ -1,5 +1,5 @@
 ---
-sourcePath: core/reference/ydb-sdk/example/_includes/aux/pragmatablepathprefix.md
+sourcePath: core/reference/ydb-sdk/example/_includes/auxa/pragmatablepathprefix.md
 ---
 `PRAGMA TablePathPrefix` добавляет указанный префикс к путям таблиц внутри БД. Работает по принципу объединения путей в файловой системе — поддерживает ссылки на родительский каталог и не требует добавления слеша справа. Например:
 

--- a/ru/ydb/reference/ydb-sdk/example/_includes/example-dotnet.md
+++ b/ru/ydb/reference/ydb-sdk/example/_includes/example-dotnet.md
@@ -5,7 +5,7 @@ sourcePath: core/reference/ydb-sdk/example/_includes/example-dotnet.md
 
 На этой странице подробно разбирается код [тестового приложения](https://github.com/ydb-platform/ydb-dotnet-examples), доступного в составе [C# (.NET) SDK](https://github.com/ydb-platform/ydb-dotnet-sdk) YDB.
 
-{% include [addition.md](aux/addition.md) %}
+{% include [addition.md](auxa/addition.md) %}
 
 {% include [init.md](steps/01_init.md) %}
 
@@ -76,7 +76,7 @@ var response = await tableClient.SessionExec(async session =>
 response.Status.EnsureSuccess();
 ```
 
-{% include [pragmatablepathprefix.md](aux/pragmatablepathprefix.md) %}
+{% include [pragmatablepathprefix.md](auxa/pragmatablepathprefix.md) %}
 
 {% include [query_processing.md](steps/03_query_processing.md) %}
 

--- a/ru/ydb/reference/ydb-sdk/example/_includes/example-go.md
+++ b/ru/ydb/reference/ydb-sdk/example/_includes/example-go.md
@@ -5,7 +5,7 @@ sourcePath: core/reference/ydb-sdk/example/_includes/example-go.md
 
 На этой странице подробно разбирается код [тестового приложения](https://github.com/yandex-cloud/ydb-go-sdk/tree/master/example/basic_example_v1), доступного в составе [Go SDK](https://github.com/yandex-cloud/ydb-go-sdk) YDB.
 
-{% include [addition.md](aux/addition.md) %}
+{% include [addition.md](auxa/addition.md) %}
 
 {% include [init.md](steps/01_init.md) %}
 
@@ -77,7 +77,7 @@ func describeTable(ctx context.Context, sp *table.SessionPool, path string) (err
   )
 ```
 
-{% include [pragmatablepathprefix.md](aux/pragmatablepathprefix.md) %}
+{% include [pragmatablepathprefix.md](auxa/pragmatablepathprefix.md) %}
 
 {% include [query_processing.md](steps/03_query_processing.md) %}
 

--- a/ru/ydb/reference/ydb-sdk/example/_includes/example-java.md
+++ b/ru/ydb/reference/ydb-sdk/example/_includes/example-java.md
@@ -98,7 +98,7 @@ private void describeTables() {
 }
 ```
 
-{% include [pragmatablepathprefix.md](aux/pragmatablepathprefix.md) %}
+{% include [pragmatablepathprefix.md](auxa/pragmatablepathprefix.md) %}
 
 {% include [query_processing.md](steps/03_query_processing.md) %}
 

--- a/ru/ydb/reference/ydb-sdk/example/_includes/example-nodejs.md
+++ b/ru/ydb/reference/ydb-sdk/example/_includes/example-nodejs.md
@@ -5,7 +5,7 @@ sourcePath: core/reference/ydb-sdk/example/_includes/example-nodejs.md
 
 На этой странице подробно разбирается код [тестового приложения](https://github.com/ydb-platform/ydb-nodejs-sdk/tree/master/examples/basic-example-v1), доступного в составе [Node.js SDK](https://github.com/yandex-cloud/ydb-nodejs-sdk) YDB.
 
-{% include [addition.md](aux/addition.md) %}
+{% include [addition.md](auxa/addition.md) %}
 
 {% include [scan_query.md](steps/08_scan_query.md) %}
 

--- a/ru/ydb/reference/ydb-sdk/example/_includes/example-php.md
+++ b/ru/ydb/reference/ydb-sdk/example/_includes/example-php.md
@@ -5,7 +5,7 @@ sourcePath: core/reference/ydb-sdk/example/_includes/example-php.md
 
 На этой странице подробно разбирается код тестового приложения, доступного в составе [PHP SDK](https://github.com/yandex-cloud/ydb-php-sdk) YDB.
 
-{% include [addition.md](aux/addition.md) %}
+{% include [addition.md](auxa/addition.md) %}
 
 {% include [init.md](steps/01_init.md) %}
 

--- a/ru/ydb/reference/ydb-sdk/example/_includes/example-python.md
+++ b/ru/ydb/reference/ydb-sdk/example/_includes/example-python.md
@@ -68,7 +68,7 @@ def describe_table(session, path, name):
 ('column, name:', 'release_date', ',', 'type_id: UINT64')
 ```
 
-{% include [pragmatablepathprefix.md](aux/pragmatablepathprefix.md) %}
+{% include [pragmatablepathprefix.md](auxa/pragmatablepathprefix.md) %}
 
 {% include [create_table.md](steps/03_query_processing.md) %}
 


### PR DESCRIPTION
Переименована папка
ru/ydb/reference/ydb-sdk/example/_includes/auxa/addition.md
сделано для совместимости с windows - потому что в windows папка не может называться aux (git pull дает ошибку)

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
