### PR TITLE
Fix type in AWS Recognition service name

### DIFF
--- a/ru/overview/platform-comparison/aws.md
+++ b/ru/overview/platform-comparison/aws.md
@@ -36,5 +36,5 @@
 | AWS Shield | [{{ ddos-protection-full-name }}](../../vpc/ddos-protection/) |
 | Elastic Load Balancing: Network Load Balancer | [{{ network-load-balancer-full-name }}](../../network-load-balancer/) |
 | Polly, Transcribe | [{{ speechkit-full-name }}](../../speechkit/) |
-| Rekognition | [{{ vision-full-name }}](../../vision/) |
+| Recognition | [{{ vision-full-name }}](../../vision/) |
 | Translate | [{{ translate-full-name }}](../../translate/) |


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
Исправил ошибку в названии AWS сервиса Recognition