### PR TITLE
The service called strongswan-starter, not strongswan

### DIFF
--- a/ru/solutions/routing/ipsec-vpn.md
+++ b/ru/solutions/routing/ipsec-vpn.md
@@ -118,7 +118,7 @@
 1. Перезапустите strongSwan:
 
    ```
-   $ systemctl restart strongswan
+   $ systemctl restart strongswan-starter
    ```
 
 ## Настройте статическую маршрутизацию {#configure-static-route}
@@ -182,7 +182,7 @@
 1. Перезапустите strongSwan:
 
    ```
-   $ systemctl restart strongswan
+   $ systemctl restart strongswan-starter
    ```
 
 ## Проверьте работу IPSec-туннеля {#test-vpn}


### PR DESCRIPTION
The service called strongswan-starter, not strongswan

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
