### PR TITLE
Ошибка datalens to data_lens

### DIFF
--- a/ru/managed-clickhouse/operations/cluster-create.md
+++ b/ru/managed-clickhouse/operations/cluster-create.md
@@ -248,7 +248,7 @@
         resource "yandex_mdb_clickhouse_cluster" "<имя кластера>" {
           ...
           access {
-            datalens   = <Доступ из DataLens: true или false>
+            data_lens  = <Доступ из DataLens: true или false>
             metrika    = <Доступ из Метрики и AppMetrika: true или false>
             serverless = <Доступ из Cloud Functions: true или false>
             web_sql    = <Выполнение SQL-запросов из консоли управления: true или false>


### PR DESCRIPTION
Error: Unsupported argument
An argument named "datalens" is not expected here. Did you mean "data_lens"?
Доказательство:
https://registry.terraform.io/providers/yandex-cloud/yandex/latest/docs/resources/mdb_clickhouse_cluster

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
