### PR TITLE
Нерабочий Quickstart по Yandex Serverless Containers 

### DIFF
--- a/en/serverless-containers/quickstart.md
+++ b/en/serverless-containers/quickstart.md
@@ -18,61 +18,101 @@ To prepare a container's Docker image:
 
 - Node.js
 
-    **Application**
+    **index.js**
 
     ```js
-    import express from "express";
+    const express = require('express');
 
     const app = express();
     app.use(express.urlencoded({ extended: true }));
     app.use(express.json());
 
-    app.post("/", (req, res) => {
-
-        console.log("Say hello from Serverless Docker Node Container!");
-
-        return res.send("Success!");
+    app.get("/hello", (req, res) => {
+        var ip = req.headers['x-forwarded-for']
+        console.log(`Request from ${ip}`);
+        return res.send("Hello!");
     });
 
     app.listen(process.env.PORT, () => {
-        console.log(`App listening at http://localhost:${process.env.PORT}`);
+        console.log(`App listening at port ${process.env.PORT}`);
     });
     ```
 
     **Dockerfile**
 
     ```
-    FROM node:14-alpine
-    # Learn more about libc6-compat: https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine.
-    RUN apk add --no-cache libc6-compat
+    FROM node:16-slim
+
     WORKDIR /app
-    COPY ./dist .
-    RUN npm ci
+    RUN npm install express
+    COPY ./index.js .
+
     CMD [ "node", "index.js" ]
+    ```
+
+- Python
+
+    **index.py**
+
+    ```python
+    import os
+    from sanic import Sanic
+    from sanic.response import text
+
+    app = Sanic(__name__)
+
+    @app.after_server_start
+    async def after_server_start(app, loop):
+        print(f"App listening at port {os.environ['PORT']}")
+
+    @app.route("/hello")
+    async def hello(request):
+        ip = request.headers["X-Forwarded-For"]
+        print(f"Request from {ip}")
+        return text("hello!")
+
+    if __name__ == "__main__":
+        app.run(host='0.0.0.0', port=os.environ['PORT'], motd=False, access_log=False)
+    ```
+
+    **Dockerfile**
+
+    ```
+    FROM python:3.10-slim
+
+    WORKDIR /app
+    RUN pip install --no-cache-dir --prefer-binary sanic
+    COPY ./index.py .
+
+    CMD [ "python", "index.py" ]
     ```
 
 - Go
 
-    **Application**
+    **index.go**
 
     ```golang
     package main
 
     import (
+        "fmt"
         "net/http"
         "os"
     )
 
     func main() {
         portStr := os.Getenv("PORT")
-        http.ListenAndServe(":" + portStr, hwHandler{})
+        fmt.Printf("App listening at port %s\n", portStr)
+        http.ListenAndServe(":"+portStr, hwHandler{})
     }
 
     type hwHandler struct{}
 
     func (hwHandler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+        ip := request.Header.Get("X-Forwarded-For")
+        fmt.Printf("Request from %s\n", ip)
         writer.WriteHeader(200)
-        _, _ = writer.Write([]byte("Hello world!"))
+        _, _ = writer.Write([]byte("Hello!"))
     }
     ```
 
@@ -80,14 +120,16 @@ To prepare a container's Docker image:
 
     ```
     FROM golang:latest AS build
-    RUN mkdir /app
-    ADD . /app/
+
     WORKDIR /app
-    RUN go build -a -tags netgo -ldflags '-w -extldflags "-static"' -o server-app *.go
+    ADD index.go .
+    RUN go mod init main
+    RUN go build -a -tags netgo -ldflags '-w -extldflags "-static"' -o main *.go
 
     FROM scratch
-    COPY --from=build /app/server-app /server-app
-    ENTRYPOINT ["/server-app"]
+    COPY --from=build /app/main /main
+
+    ENTRYPOINT ["/main"]
     ```
 
 {% endlist %}
@@ -113,5 +155,5 @@ curl -H "Authorization: Bearer $(yc iam create-token)" https://bba3fva6ka5g*****
 Result:
 
 ```
-Hello world!
+Hello!
 ```


### PR DESCRIPTION
Docker образы не собирались, поправил сделав их самодостаточными.
Реализация Node.js и Golang отличалась в части url, логов и ответов приложения, сделал везде одинаковыми.
Добавил реализацию на python.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
1. Пример с приложениями полностью не рабочий, и без желания и усилий его не запустить
2. Старался сделать что бы было максимально простые реализации с минимум кода и файлов
3. Поэтому унес package management в Dockerfile
4. В python отказался от Flask в пользу Sanic что бы не ташить gunicorn
5. Отказался от alpine в пользу debian slim в силу проблем Node.js и Python c musl lib, образы вырасли несильно (10-15мб)