### PR TITLE
version of python elastic search was added

### DIFF
--- a/ru/_includes/mdb/mes-conn-strings.md
+++ b/ru/_includes/mdb/mes-conn-strings.md
@@ -108,7 +108,7 @@
   
   ```bash
   sudo apt update && sudo apt install -y python3 python3-pip && \
-  pip3 install elasticsearch
+  pip3 install elasticsearch==7.17.2
   ```
 
   **Пример кода для подключения с использованием SSL-соединения:**


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
Version of elasticsearch package was changed to 7.17.2, because provided script do not work if you install elasticsearch with suggested pip3 command(it will install the latest 8 version). Actual code work well for elasticsearch module of versions that are smaller than 8. At new elasticsearch version(8 and greater) there is no 'use_ssl'.
