### PR TITLE
Fix error in docs: --permission instead of --role

### DIFF
--- a/ru/_includes/mdb/mmg-user-examples.md
+++ b/ru/_includes/mdb/mmg-user-examples.md
@@ -52,7 +52,7 @@
   {{ yc-mdb-mg }} user grant-permission user1 \
      --cluster-name cluster1 \
      --database db2 \
-     --permission read
+     --role read
   ```
 
 - Terraform


### PR DESCRIPTION
Docs have an error in parameter name. If you copy-paste the command docs, you will receive an error: ERROR: unknown flag: --permission

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
