### PR TITLE
Fix Clickhouse data clean policy links for Data Transfer

### DIFF
--- a/en/data-transfer/operations/endpoint/target/clickhouse.md
+++ b/en/data-transfer/operations/endpoint/target/clickhouse.md
@@ -53,7 +53,7 @@ Connecting to the database with explicitly specified network addresses and ports
 
     * **Write interval**: Specify the delay with which the data should arrive at the target cluster. Increase the value in this field if ClickHouse does not have time to merge pieces of data.
 
-    * {% include [Field Cleanum Policy Drop/Disabled](../../../../_includes/data-transfer/fields/common/ui/cleanup-policy-disabled-drop.md) %}
+    * {% include [Field Cleanup Policy Disabled/Drop/Truncate](../../../../_includes/data-transfer/fields/common/ui/cleanup-policy-disabled-drop-truncate.md) %}
 
 {% endlist %}
 

--- a/ru/data-transfer/operations/endpoint/target/clickhouse.md
+++ b/ru/data-transfer/operations/endpoint/target/clickhouse.md
@@ -55,6 +55,6 @@
 
     * **Интервал записи** — укажите задержку, с которой данные должны поступать в кластер-приемник. Увеличьте значение в этом поле, если ClickHouse не успевает делать слияние кусков данных.
 
-    * {% include [Field Cleanum Policy Drop/Disabled](../../../../_includes/data-transfer/fields/common/ui/cleanup-policy-disabled-drop.md) %}
+    * {% include [Field Cleanup Policy Disabled/Drop/Truncate](../../../../_includes/data-transfer/fields/common/ui/cleanup-policy-disabled-drop-truncate.md) %}
 
 {% endlist %}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
Fix Clickhouse data clean policy links for Data Transfer (Truncate is also supported) 
<img width="590" alt="image" src="https://user-images.githubusercontent.com/13064229/172042694-f701d03c-2e60-444b-b369-63614b8af863.png">

