### PR TITLE
Добавил примечание к curl-запросу для Виндоусе

### DIFF
--- a/ru/_includes/telegram-bot-serverless.md
+++ b/ru/_includes/telegram-bot-serverless.md
@@ -236,10 +236,13 @@ description: "В этом сценарии вы узнаете, как с пом
   1. Нажмите кнопку **Сохранить**.
   1. Выполните запрос, вместо `<токен бота>` укажите токен Telegram-бота, вместо `<домен API-шлюза>` — служебный домен API-шлюза:
       ```bash
-      curl --request POST --url https://api.telegram.org/bot<токен бота>/setWebhook \
-      --header 'content-type: application/json' --data '{"url": "<домен API-шлюза>/fshtb-function"}'
-      ```
-    
+      curl --request POST --url https://api.telegram.org/bot<токен бота>/setWebhook --header 'content-type: application/json' --data '{"url": "<домен API-шлюза>/fshtb-function"}'
+      ```      
+      В ОС Windows запрос может возвращать ошибку. Вероятно, это связано с неправильной обработкой некоторых символов. Попробуйте заменить апострофы `'` на кавычки `"` и экранировать фигурные скобки. Итоговый запрос будет выглядеть так:
+      ```bash
+      curl --request POST --url https://api.telegram.org/bot<токен бота>/setWebhook --header 'content-type:application/json' --data "{\"url\": \"<домен API-шлюза>/fshtb-function\"}"
+      ```     
+      
       Результат:
 
       ```bash

--- a/ru/_includes/telegram-bot-serverless.md
+++ b/ru/_includes/telegram-bot-serverless.md
@@ -235,13 +235,26 @@ description: "В этом сценарии вы узнаете, как с пом
 
   1. Нажмите кнопку **Сохранить**.
   1. Выполните запрос, вместо `<токен бота>` укажите токен Telegram-бота, вместо `<домен API-шлюза>` — служебный домен API-шлюза:
-      ```bash
-      curl --request POST --url https://api.telegram.org/bot<токен бота>/setWebhook --header 'content-type: application/json' --data '{"url": "<домен API-шлюза>/fshtb-function"}'
-      ```      
-      В ОС Windows запрос может возвращать ошибку. Вероятно, это связано с неправильной обработкой некоторых символов. Попробуйте заменить апострофы `'` на кавычки `"` и экранировать фигурные скобки. Итоговый запрос будет выглядеть так:
-      ```bash
-      curl --request POST --url https://api.telegram.org/bot<токен бота>/setWebhook --header 'content-type:application/json' --data "{\"url\": \"<домен API-шлюза>/fshtb-function\"}"
-      ```     
+      * Linux, macOS:
+
+        ```bash
+        curl --request POST --url https://api.telegram.org/bot<токен бота>/setWebhook \
+          --header 'content-type: application/json' --data '{"url": "<домен API-шлюза>/fshtb-function"}'
+        ```
+    
+      * Windows (cmd):
+
+        ```bash
+        curl --request POST --url https://api.telegram.org/bot<токен бота>/setWebhook ^
+          --header "content-type: application/json" --data "{\"url\": \"<домен API-шлюза>/fshtb-function\"}"
+        ```
+
+      * Windows (PowerShell):
+      
+        ```powershell
+        curl.exe --request POST --url https://api.telegram.org/bot<токен бота>/setWebhook `
+          --header '"content-type: application/json"' --data '"{ \"url\": \"<домен API-шлюза>/fshtb-function\" }"'
+        ``` 
       
       Результат:
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:

Оригинальный запрос, который указан в статье, в Виндоусе возвращает ошибку. Опытным путем установил, что дело в том, как парсятся символы. Запрос, который я привожу, у меня сработал. 

На решение натолкнул ответ на SO: https://stackoverflow.com/a/69610904.
