### PR TITLE
Pre-signed url via AWS CLI update with --endpoint-url

### DIFF
--- a/en/storage/concepts/pre-signed-urls.md
+++ b/en/storage/concepts/pre-signed-urls.md
@@ -207,6 +207,8 @@ Create a signed URL to download the `object-for-share.txt` object from `example-
     ```
     aws s3 presign s3://<bucket-name>/<object-key> --endpoint-url "https://{{ s3-storage-host }}/" [--expires-in <value>]
     ```
+  
+    For a link to be generated properly, the `--endpoint-url` parameter pointing to {{ objstorage-name }} hostname is required. For details, see the [section about AWS CLI specifics](../tools/aws-cli.md#specifics). 
 
 - boto3
 

--- a/en/storage/concepts/pre-signed-urls.md
+++ b/en/storage/concepts/pre-signed-urls.md
@@ -205,7 +205,7 @@ Create a signed URL to download the `object-for-share.txt` object from `example-
     You can also use AWS CLI to generate a link for object download. To do this, run the following command:
 
     ```
-    aws s3 presign s3://<bucket-name>/<object-key> --endpoint-url "https://storage.yandexcloud.net/" [--expires-in <value>]
+    aws s3 presign s3://<bucket-name>/<object-key> --endpoint-url "https://{{ s3-storage-host }}/" [--expires-in <value>]
     ```
 
 - boto3

--- a/en/storage/concepts/pre-signed-urls.md
+++ b/en/storage/concepts/pre-signed-urls.md
@@ -205,7 +205,7 @@ Create a signed URL to download the `object-for-share.txt` object from `example-
     You can also use AWS CLI to generate a link for object download. To do this, run the following command:
 
     ```
-    aws s3 presign s3://<bucket-name>/<object-key> [--expires-in <value>]
+    aws s3 presign s3://<bucket-name>/<object-key> --endpoint-url "https://storage.yandexcloud.net/" [--expires-in <value>]
     ```
 
 - boto3

--- a/ru/storage/concepts/pre-signed-urls.md
+++ b/ru/storage/concepts/pre-signed-urls.md
@@ -212,7 +212,7 @@ host;x-amz-date
     Ссылку на скачивание объекта также можно сгенерировать с помощью AWS CLI. Для этого выполните команду вида:
 
     ```
-    aws s3 presign s3://<bucket-name>/<object-key> [--expires-in <value>]
+    aws s3 presign s3://<bucket-name>/<object-key> --endpoint-url "https://storage.yandexcloud.net/" [--expires-in <value>]
     ```
 
 - boto3

--- a/ru/storage/concepts/pre-signed-urls.md
+++ b/ru/storage/concepts/pre-signed-urls.md
@@ -212,7 +212,7 @@ host;x-amz-date
     Ссылку на скачивание объекта также можно сгенерировать с помощью AWS CLI. Для этого выполните команду вида:
 
     ```
-    aws s3 presign s3://<bucket-name>/<object-key> --endpoint-url "https://storage.yandexcloud.net/" [--expires-in <value>]
+    aws s3 presign s3://<bucket-name>/<object-key> --endpoint-url "https://{{ s3-storage-host }}/" [--expires-in <value>]
     ```
 
 - boto3

--- a/ru/storage/concepts/pre-signed-urls.md
+++ b/ru/storage/concepts/pre-signed-urls.md
@@ -214,6 +214,8 @@ host;x-amz-date
     ```
     aws s3 presign s3://<bucket-name>/<object-key> --endpoint-url "https://{{ s3-storage-host }}/" [--expires-in <value>]
     ```
+  
+    Чтобы ссылка сформировалась корректно, обязательно укажите параметр `--endpoint-url` с указанием на доменное имя {{ objstorage-name }}. Подробнее см. в [разделе об особенностях работы AWS CLI](../tools/aws-cli.md#specifics).
 
 - boto3
     


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:

Использование AWS CLI для подписи Url без указания `--endpoint-url "https://storage.yandexcloud.net/"` создает некорректную ссылку:

![image](https://user-images.githubusercontent.com/89912354/172557957-2d28abff-a215-432b-88aa-b4a6c1738433.png)
