### PR TITLE
Update kubernetes-cluster-namespace-create.md

### DIFF
--- a/ru/managed-kubernetes/operations/kubernetes-cluster/kubernetes-cluster-namespace-create.md
+++ b/ru/managed-kubernetes/operations/kubernetes-cluster/kubernetes-cluster-namespace-create.md
@@ -2,7 +2,7 @@
 
 {% note info %}
 
-Создание [пространства имен](../../concepts/index.md#namespace) в кластере {{ k8s }} находится на стадии [Preview](../../../overview/concepts/launch-stages.md).
+Создание [пространства имен](../../concepts/index.md#namespace) в кластере {{ k8s }} с помощью консоли управления находится на стадии [Preview](../../../overview/concepts/launch-stages.md).
 
 {% endnote %}
 


### PR DESCRIPTION
Clarify that preview warning does not refer to kubectl

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
Сейчас эту фразу можно неправильно понять в том смысле, что в Managed Service for Kubernetes вообще нет production-ready поддержки нескольких неймспейсов.