### PR TITLE
SOA-запись - значение по-умолчанию для RNAME

### DIFF
--- a/en/dns/concepts/resource-record.md
+++ b/en/dns/concepts/resource-record.md
@@ -151,7 +151,7 @@ It consists of the following parts:
 * `MNAME`: The domain name of the server that handles the zone. Default: 0.
    * `ns.internal.` for private zones.
    * `ns1.yandexcloud.net.` for public zones.
-* `RNAME`: The domain name of the mail server that handles the zone. Default value: `{{ dns-mx-host }}`.
+* `RNAME`: The domain name of the mail server that handles the zone. Default value: `mx.cloud.yandex.net.`.
 * `SERIAL`: An unsigned 32-bit integer that points to the number of a zone copy. When synchronizing data between DNS servers, the value in the `SERIAL` field is checked. The larger it is, the more recent the data. The default value is `1`.
 
    {% note warning %}

--- a/en/dns/concepts/resource-record.md
+++ b/en/dns/concepts/resource-record.md
@@ -151,7 +151,7 @@ It consists of the following parts:
 * `MNAME`: The domain name of the server that handles the zone. Default: 0.
    * `ns.internal.` for private zones.
    * `ns1.yandexcloud.net.` for public zones.
-* `RNAME`: The domain name of the mail server that handles the zone. Default value: `mx.cloud.yandex.net.`.
+* `RNAME`: The domain name of the mail server that handles the zone. Default value: `{{ dns-mx-host }}.`.
 * `SERIAL`: An unsigned 32-bit integer that points to the number of a zone copy. When synchronizing data between DNS servers, the value in the `SERIAL` field is checked. The larger it is, the more recent the data. The default value is `1`.
 
    {% note warning %}


### PR DESCRIPTION
Изменил значение SOA-записи RNAME на "mx.cloud.yandex.net.", добавил точку в конце. В табличке ниже есть пример такой записи (с точкой в конце), также при в интерфейсе Yandex Cloud DNS это значение также имеет точку в конце.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
