### PR TITLE
Fix plugin name

### DIFF
--- a/en/managed-elasticsearch/tutorials/migration-via-snapshots.md
+++ b/en/managed-elasticsearch/tutorials/migration-via-snapshots.md
@@ -41,7 +41,7 @@ To migrate data from the *source cluster* in {{ ES }} to the {{ mes-name }} *tar
    1. Click **Add**.
    1. Click **Save**.
 
-1. [Install](https://www.elastic.co/guide/en/elasticsearch/plugins/7.16/repository-s3.html) the `s3-repository` plugin on the source cluster.
+1. [Install](https://www.elastic.co/guide/en/elasticsearch/plugins/7.16/repository-s3.html) the `repository-s3` plugin on the source cluster.
 
    It must be installed on **all hosts** of the source cluster. Once you have installed it, you'll need to restart the {{ ES }} services and Kibana on the hosts.
 

--- a/ru/managed-elasticsearch/tutorials/migration-via-snapshots.md
+++ b/ru/managed-elasticsearch/tutorials/migration-via-snapshots.md
@@ -46,7 +46,7 @@
     1. Нажмите кнопку **Добавить**.
     1. Нажмите кнопку **Сохранить**.
 
-1. [Установите расширение](https://www.elastic.co/guide/en/elasticsearch/plugins/7.16/repository-s3.html) `s3-repository` на кластере-источнике.
+1. [Установите расширение](https://www.elastic.co/guide/en/elasticsearch/plugins/7.16/repository-s3.html) `repository-s3` на кластере-источнике.
 
     Расширение должно быть установлено на **всех хостах** кластера-источника. После установки потребуется перезапуск сервисов {{ ES }} и Kibana на хостах.
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
Plugin name is ["repository-s3"](https://www.elastic.co/guide/en/elasticsearch/plugins/7.16/repository-s3.html)
![repository-s3](https://user-images.githubusercontent.com/90443642/179471717-70e0304e-9d9a-4d10-b43c-ab56e24b72c7.png)

