### PR TITLE
Кавычки -d '@body.json'

### DIFF
--- a/ru/speechkit/stt/api/transcribation-ogg.md
+++ b/ru/speechkit/stt/api/transcribation-ogg.md
@@ -28,7 +28,7 @@
        export IAM_TOKEN=<IAM-токен>
        curl -X POST \
            -H "Authorization: Bearer ${IAM_TOKEN}" \
-           -d '@body.json' \
+           -d "@body.json" \
            https://transcribe.{{ api-host }}/speech/stt/v2/longRunningRecognize
  
        {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
Вероятно для linux пример с одинарными кавычками работает, но под Windows исполнение такого запроса вываливает ошибку "Root element must be a message". Использование двойных кавычек решает проблему. 
Писал об этом тут - https://st.yandex-team.ru/CLOUDSUPPORT-163362

billing-id: dn204jl65btpjo9colgh