### PR TITLE
Fixing unvalid example on certificate/v1

### DIFF
--- a/ru/dns/tutorials/cert-manager-webhook.md
+++ b/ru/dns/tutorials/cert-manager-webhook.md
@@ -100,8 +100,8 @@
       # The issuer created previously
       name: clusterissuer
       kind: ClusterIssuer
-    dnsNames:
-     - your-site.com
+     dnsNames:
+       - your-site.com
     ```
 
 ## Запустите менеджер сертификатов с веб-хуком {#run-webhook}


### PR DESCRIPTION
Official documentation: https://cert-manager.io/docs/concepts/certificate/

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes: 
Correction of documentation in certificate examples
