### PR TITLE
Fix SSH params

### DIFF
--- a/ru/compute/operations/serial-console/connect-ssh.md
+++ b/ru/compute/operations/serial-console/connect-ssh.md
@@ -26,7 +26,7 @@
     Рекомендуемые параметры запуска:
 
     ```bash
-    ssh -o ControlPath=none -o IdentitiesOnly=yes -o CheckHostIP=no -o StrictHostKeyChecking=yes -o UserKnownHostsFile=./serialssh-knownhosts -p 9600 -i ~/.ssh/<имя закрытого ключа> <ID виртуальной машины>.<имя пользователя>@serialssh.cloud.yandex.net
+    ssh -o ControlPath=none -o IdentitiesOnly=yes -o CheckHostIP=no -o StrictHostKeyChecking=yes -o UserKnownHostsFile=./serialssh-knownhosts -o PubkeyAcceptedKeyTypes=ssh-rsa -p 9600 -i ~/.ssh/<имя закрытого ключа> <ID виртуальной машины>.<имя пользователя>@serialssh.cloud.yandex.net
     ```
 
     Публичный ключ хоста в будущем может быть изменен.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:

Without `PubkeyAcceptedKeyTypes=ssh-rsa` option SSH will fail with `Permission denied (publickey)` error