### PR TITLE
Remove deprecated interpolation syntax in http-router-create

### DIFF
--- a/en/application-load-balancer/operations/http-router-create.md
+++ b/en/application-load-balancer/operations/http-router-create.md
@@ -141,7 +141,7 @@ To create an HTTP router and add a route to it:
       
       resource "yandex_alb_virtual_host" "my-virtual-host" {
         name           = "<virtual host name>"
-        http_router_id = "${yandex_alb_http_router.tf-router.id}"
+        http_router_id = yandex_alb_http_router.tf-router.id
         route {
           name = "<route name>"
           http_route {

--- a/ru/application-load-balancer/operations/http-router-create.md
+++ b/ru/application-load-balancer/operations/http-router-create.md
@@ -138,7 +138,7 @@
     
      resource "yandex_alb_virtual_host" "my-virtual-host" {
        name           = "<имя виртуального хоста>"
-       http_router_id = "${yandex_alb_http_router.tf-router.id}"
+       http_router_id = yandex_alb_http_router.tf-router.id
        route {
          name = "<имя маршрута>"
          http_route {


### PR DESCRIPTION
Могу присылать PR где понемногу удаляю интерполяцию, используемую в старых версиях terraform. Делать подобные PR ?

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
