### PR TITLE
Update s3-csi-integration.md

### DIFF
--- a/ru/managed-kubernetes/operations/volumes/s3-csi-integration.md
+++ b/ru/managed-kubernetes/operations/volumes/s3-csi-integration.md
@@ -184,7 +184,7 @@
           command: ["/bin/sh"]
           args: ["-c", "for i in {1..10}; do echo $(date -u) >> /data/s3-dynamic/dynamic-date.txt; sleep 10; done"]
           volumeMounts:
-            - mountPath: /data/dynamic
+            - mountPath: /data/s3-dynamic
               name: s3-volume
         volumes:
           - name: s3-volume


### PR DESCRIPTION
fixed spec.containers.volumeMounts.mountPath in pod-dynamic.yaml. 


I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
If we want to write to a file /data/s3-dynamic/dynamic-date.txt , then the mountPath should be appropriate