### PR TITLE
remove wrong variable, that overrides config

### DIFF
--- a/ru/monitoring/operations/unified-agent/linux_metrics.md
+++ b/ru/monitoring/operations/unified-agent/linux_metrics.md
@@ -83,7 +83,6 @@
       -v `pwd`/config.yml:/etc/yandex/unified_agent/config.yml \
       -v /proc:/ua_proc \
       -e PROC_DIRECTORY=/ua_proc \
-      -e FOLDER_ID=a1bs... \
       cr.yandex/yc/unified-agent
       ```
 


### PR DESCRIPTION
Переменная окружения FOLDER_ID переопределяет значение folder_id из конфига

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
