### PR TITLE
Update security-group-add-rule - clarify `self` rule.

### DIFF
--- a/en/vpc/operations/security-group-add-rule.md
+++ b/en/vpc/operations/security-group-add-rule.md
@@ -95,6 +95,15 @@ You do not need to restart a VM when adding or deleting rules. The rules are app
               - 10.10.0.0/24
            ...
       ```
+      
+      {% note info %}
+      
+      You can use `predefined=self_security_group` to apply a rule on the current security group.
+      
+      For more information about the rule `Self` see the documentation on [types of rules](../concepts/security-groups.md#rules-types).
+      
+      {% endnote %}
+      
       To get help about the `--add-rule` parameter, run `yc vpc security-group update-rules --help`.
 
 - {{ TF }}

--- a/ru/vpc/operations/security-group-add-rule.md
+++ b/ru/vpc/operations/security-group-add-rule.md
@@ -100,7 +100,7 @@
      
      Вы можете использовать `predefined=self_security_group` что бы задействовать правило на машины внутри изменяемой группы безопасности.
      
-     Подробнее о правиле `Self` читайте в [видах правил групп безопасности](../../concepts/security-groups.md#rules-types).
+     Подробнее о правиле `Self` читайте в [видах правил групп безопасности](../concepts/security-groups.md#rules-types).
      
      {% endnote %}
      

--- a/ru/vpc/operations/security-group-add-rule.md
+++ b/ru/vpc/operations/security-group-add-rule.md
@@ -95,6 +95,15 @@
              - 10.10.0.0/24
           ...
      ```
+     
+     {% note info %}
+     
+     Вы можете использовать `predefined=self_security_group` что бы задействовать правило на машины внутри изменяемой группы безопасности.
+     
+     Подробнее о правиле `Self` читайте в [видах правил групп безопасности](../../concepts/security-groups.md#rules-types).
+     
+     {% endnote %}
+     
      Чтобы получить справку о параметре `--add-rule`, выполните команду `yc vpc security-group update-rules --help`.
 
 - Terraform


### PR DESCRIPTION
Noted about `predefined=self_security_group` in howtos of security groups.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
 * Added a note on how to use Self rule within security groups.