### PR TITLE
Add set name to block host

### DIFF
--- a/ru/managed-postgresql/operations/cluster-create.md
+++ b/ru/managed-postgresql/operations/cluster-create.md
@@ -206,6 +206,7 @@
 
        host {
          zone      = "<зона доступности>"
+         name      = "<имя хоста>"
          subnet_id = "<идентификатор подсети>"
        }
      }
@@ -385,6 +386,7 @@
 
     host {
       zone      = "{{ region-id }}-a"
+      name      = "mypg-host-a"
       subnet_id = yandex_vpc_subnet.mysubnet.id
     }
   }


### PR DESCRIPTION
Если не указывать имя хоста, то назначение публичного IP на существующий кластер будет вызывать пересоздание хоста. Уточнил по заявке 166644443673302.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
