### PR TITLE
изменено слово "облако" на "каталог"

### DIFF
--- a/RU/аудит-тропы/операции/export-folder-bucket.md
+++ b/RU/аудит-тропы/операции/export-folder-bucket.md
@@ -27,7 +27,7 @@
 
       {% include [default-catalogue](../../_includes/default-catalogue.md) %}
 
-      * Назначьте роль [`audit-trails.viewer`](../security/index.md#roles) на облако, со всех ресурсов которого будут собираться аудитные логи:
+      * Назначьте роль [`audit-trails.viewer`](../security/index.md#roles) на каталог, со всех ресурсов которого будут собираться аудитные логи:
 
         ```
         yc resource-manager folder add-access-binding \


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
На странице "Загрузка аудитных логов каталога в Object Storage" заменено слово "облако" на "каталог" в первом примере.

