### PR TITLE
замена "облако" на "каталог"

### DIFF
--- a/ru/audit-trails/operations/export-folder-bucket.md
+++ b/ru/audit-trails/operations/export-folder-bucket.md
@@ -23,7 +23,7 @@
 
       {% include [default-catalogue](../../_includes/default-catalogue.md) %}
 
-      * Назначьте роль [`audit-trails.viewer`](../security/index.md#roles) на облако, со всех ресурсов которого будут собираться аудитные логи:
+      * Назначьте роль [`audit-trails.viewer`](../security/index.md#roles) на каталог, со всех ресурсов которого будут собираться аудитные логи:
 
         ```
         yc resource-manager folder add-access-binding \


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
В статье идёт описание настройки фолдера, в примере предлагается сменить права на облако, хотя в самих командах права меняются для фолдера.