### PR TITLE
Changed request method from POST to GET

### DIFF
--- a/ru/speechkit/tts/request.md
+++ b/ru/speechkit/tts/request.md
@@ -11,7 +11,7 @@ API v1 поддерживает не все возможности синтез�
 ## HTTP-запрос {#http_request}
 
 ```
-POST https://tts.{{ api-host }}/speech/v1/tts:synthesize
+GET https://tts.{{ api-host }}/speech/v1/tts:synthesize
 ```
 
 ### Параметры в теле запроса {#body_params}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:

The request '/speech/v1/tts:synthesize' use method GET, not POST