### PR TITLE
Update vm-scale-scheduled.md

### DIFF
--- a/ru/_tutorials/infrastructure-management/vm-scale-scheduled.md
+++ b/ru/_tutorials/infrastructure-management/vm-scale-scheduled.md
@@ -77,7 +77,6 @@
        yc resource-manager folder add-access-binding example-folder \
          --service-account-name vm-scale-scheduled-sa \
          --role compute.admin \
-         --yc resource-manager folder add-access-binding example-folder \
          --folder-name example-folder
        ```
 

--- a/ru/_tutorials/infrastructure-management/vm-scale-scheduled.md
+++ b/ru/_tutorials/infrastructure-management/vm-scale-scheduled.md
@@ -76,7 +76,9 @@
        ```bash
        yc resource-manager folder add-access-binding example-folder \
          --service-account-name vm-scale-scheduled-sa \
-         --role compute.admin
+         --role compute.admin \
+         --yc resource-manager folder add-access-binding example-folder \
+         --folder-name example-folder
        ```
 
      * `iam.serviceAccounts.user` — для привязки сервисного аккаунта к ВМ, входящим в группу:
@@ -84,7 +86,8 @@
        ```bash
        yc resource-manager folder add-access-binding example-folder \
          --service-account-name vm-scale-scheduled-sa \
-         --role iam.serviceAccounts.user
+         --role iam.serviceAccounts.user \
+         --folder-name example-folder
        ```
        
      * `serverless.functions.invoker` — для запуска функции {{ sf-name }}:
@@ -92,7 +95,8 @@
        ```bash
        yc resource-manager folder add-access-binding example-folder \
          --service-account-name vm-scale-scheduled-sa \
-         --role serverless.functions.invoker
+         --role serverless.functions.invoker \
+         --folder-name example-folder
        ```
 
      Подробнее о команде `yc resource-manager folder add-access-binding` см. в [справочнике CLI](../../cli/cli-ref/managed-services/resource-manager/folder/add-access-binding.md).


### PR DESCRIPTION
без параметра --folder-name example-folder я получаю ошибку "ERROR: service account with name "vm-scale-scheduled-sa" not found"

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
Добавил в примеры команд параметр --folder-name, без которого получаю ошибку