### PR TITLE
Header 'x-node-alias' deprecated

### DIFF
--- a/ru/speechkit/tts/api/tts-examples-v3.md
+++ b/ru/speechkit/tts/api/tts-examples-v3.md
@@ -93,8 +93,7 @@
 
               # Отправить данные для синтеза.
               it = stub.UtteranceSynthesis(request, metadata=(
-                  ('authorization', f'Bearer {iam_token}'),
-                  ('x-node-alias', '{{ speechkit-tts-alias }}')
+                  ('authorization', f'Bearer {iam_token}')
               ))
 
               # Собрать аудиозапись по чанкам.


### PR DESCRIPTION
Header 'x-node-alias' deprecated

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
