### PR TITLE
Header 'x-node-alias' deprecated

### DIFF
--- a/ru/speechkit/stt/api/streaming-examples-v3.md
+++ b/ru/speechkit/stt/api/streaming-examples-v3.md
@@ -110,8 +110,7 @@
     
             # Отправить данные для распознавания.
             it = stub.RecognizeStreaming(gen(audio_file_name), metadata=(
-                ('authorization', f'Bearer {iam_token}'),
-                ('x-node-alias', '{{ speechkit-stt-alias }}')
+                ('authorization', f'Bearer {iam_token}')
             ))
 
             # Обработать ответы сервера и вывести результат в консоль.


### PR DESCRIPTION
Header 'x-node-alias' deprecated

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
