### PR TITLE
Fix custom_rule in auto_scale in scale_policy for instance-groups

### DIFF
--- a/ru/compute/concepts/instance-groups/policies/scale-policy.md
+++ b/ru/compute/concepts/instance-groups/policies/scale-policy.md
@@ -47,8 +47,8 @@ scale_policy:
     stabilization_duration: 120s
     cpu_utilization_rule:
       utilization_target: 75
-    custom_rules:
-    - rule_type: WORKLOAD
+    custom_rule:
+      rule_type: WORKLOAD
       metric_type: GAUGE
       metric_name: queue.messages.stored_count
       labels:


### PR DESCRIPTION
Fix error: An argument named "custom_rules" is not expected here.

And fix error: An argument named "custom_rule" is not expected here. Did you mean to define a block of type "custom_rule"?

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
