### PR TITLE
Fix custom_rule in auto_scale in scale_policy for instance-groups

### DIFF
--- a/ru/compute/concepts/instance-groups/policies/scale-policy.md
+++ b/ru/compute/concepts/instance-groups/policies/scale-policy.md
@@ -47,7 +47,7 @@ scale_policy:
     stabilization_duration: 120s
     cpu_utilization_rule:
       utilization_target: 75
-    custom_rules:
+    custom_rule:
     - rule_type: WORKLOAD
       metric_type: GAUGE
       metric_name: queue.messages.stored_count


### PR DESCRIPTION
Fix error: An argument named "custom_rules" is not expected here.

https://registry.tfpla.net/providers/yandex-cloud/yandex/latest/docs/resources/compute_instance_group#custom_rule

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
