### PR TITLE
Add more info about credentials

### DIFF
--- a/ru/storage/_includes_service/storage-sdk-setup.md
+++ b/ru/storage/_includes_service/storage-sdk-setup.md
@@ -17,3 +17,24 @@
    Некоторые приложения, предназначенные для работы с Amazon S3, не позволяют указывать регион, поэтому {{ objstorage-name }} принимает также значение `us-east-1`.
 
    {% endnote %}
+   
+
+
+Также возможен вариант явно указать статический ключ:
+   ```
+   // Подгружаем конфигрурацию из ~/.aws/*
+	cfg, err := config.LoadDefaultConfig(context.TODO(),
+      // Эндпоинт конфигурация
+	   config.WithEndpointResolverWithOptions(customResolver),
+
+	   // Прописываем в коде данные статического ключа.
+	   config.WithCredentialsProvider(credentials.StaticCredentialsProvider{
+		   Value: aws.Credentials{
+			   AccessKeyID:     AWS_ACCESS_KEY_ID,
+			   SecretAccessKey: AWS_SECRET_ACCESS_KEY,
+			   SessionToken:    "SESSION",
+			   Source:          "example hard coded credentials",
+		      },
+	      }),
+      )
+   ```


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
При взаимодействии с object storage я столкнулся с проблемой указания данных верного ключа сервисного аккаунта. Код подхватывал почему-то данные другого сервисного аккаунта, вместо нужного. 
В итоге нашел решение через явное указание пары aws_access_key_id & aws_secret_access_key. 
Думаю, этот пункт следует указать в документации. 
Спасибо
