### PR TITLE
Explain how to use COI Docker Compose spec in Terraform.

### DIFF
--- a/en/cos/tutorials/coi-with-terraform.md
+++ b/en/cos/tutorials/coi-with-terraform.md
@@ -44,6 +44,15 @@ If you don't have {{ TF }}, [install it and configure the {{ yandex-cloud }} pro
 
    Where `subnet_id` is the [subnet](../../vpc/concepts/network.md#subnet) IDs.
 
+   If you use [Docker Compose specification](../concepts/coi-specifications.md#compose-spec), then you should replace `docker-container-declaration` with `docker-compose` in `metadata` block:
+
+   ```
+   metadata = {
+     docker-compose = file("${path.module}/docker-compose.yaml")
+     user-data = file("${path.module}/cloud_config.yaml")
+   }
+   ```
+
 1. Create a cloud specification file named `cloud_config.yaml` in the `~/cloud-terraform` directory. Describe the specification:
 
    ```yaml

--- a/ru/cos/tutorials/coi-with-terraform.md
+++ b/ru/cos/tutorials/coi-with-terraform.md
@@ -44,6 +44,15 @@
 
    Где `subnet_id` — идентификатор [подсети](../../vpc/concepts/network.md#subnet).
 
+   Если вы используете [Docker Compose спецификацию](../concepts/coi-specifications.md#compose-spec), то ключ `docker-container-declaration` в `metadata` необходимо заменить на ключ `docker-compose`:
+
+   ```
+   metadata = {
+     docker-compose = file("${path.module}/docker-compose.yaml")
+     user-data = file("${path.module}/cloud_config.yaml")
+   }
+   ```
+
 1. Создайте файл спецификации облака `cloud_config.yaml` в директории `~/cloud-terraform`. Опишите спецификацию:
 
    ```yaml


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
When using Docker Compose specification in COI with Terraform, the metadata key must be changed from `docker-container-declaration` to `docker-compose`.

Billing ID: dn2apbb56ao9fkk1f1lp.