### PR TITLE
Fix field spec.provisionBySsh.sshKeySecret in NodeGroup resource

### DIFF
--- a/en/managed-kubernetes/operations/external-nodes-connect.md
+++ b/en/managed-kubernetes/operations/external-nodes-connect.md
@@ -149,7 +149,9 @@ In the `NodeGroup` resource specification, include the name of the relevant secr
     ips:
     ...
     provisionBySsh:
-      sshKeySecret: <secret name>
+      sshKeySecret:
+        name: <secret name>
+        namespace: system
   ```
 
 {% endlist %}

--- a/ru/managed-kubernetes/operations/external-nodes-connect.md
+++ b/ru/managed-kubernetes/operations/external-nodes-connect.md
@@ -149,7 +149,9 @@ kubectl -n system create secret generic <имя секрета> --from-file=ssh-
     ips:
     ...
     provisionBySsh:
-      sshKeySecret: <имя секрета>
+      sshKeySecret:
+        name: <имя секрета>
+        namespace: system
   ```
 
 {% endlist %}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:

I found that Kubernetes manifest does not match to resource definition.

```
$ kubectl explain --recursive=true nodegroup.spec
KIND:     NodeGroup
VERSION:  mks.yandex.cloud/v1alpha1

RESOURCE: spec <Object>

DESCRIPTION:
     <empty>

FIELDS:
   ips <[]string>
   provisionBySsh <Object>
      sshKeySecret <Object>
         name <string>
         namespace <string>
```