### PR TITLE
clickhouse-client DEB repository

### DIFF
--- a/ru/_includes/mdb/mch-conn-strings.md
+++ b/ru/_includes/mdb/mch-conn-strings.md
@@ -6,8 +6,8 @@
 
     ```bash
     sudo apt update && sudo apt install --yes apt-transport-https ca-certificates dirmngr && \
-    sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv E0C56BD4 && \
-    echo "deb https://repo.{{ ch-domain }}/deb/stable/ main/" | sudo tee \
+    sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 8919F6BD2B48D754 && \
+    echo "deb https://packages.{{ ch-domain }}/deb stable main" | sudo tee \
     /etc/apt/sources.list.d/clickhouse.list
     ```
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
Способ подключения DEB репозитория для clickhouse-client устарел, на офицальном сайте обновленная инструкция есть, обновил её здесь
Обновленная инструкция: https://clickhouse.com/docs/ru/getting-started/install/#install-from-deb-packages

Старый способ пробовал запустить с Ubuntu 22.04, при попытке apt update не может найти нужные файлы 
....
Ошб:7 https://packages.clickhouse.com/deb/stable stable Release
  404  Not Found [IP: 188.114.98.224 443]
Чтение списков пакетов… Готово            
E: Репозиторий «https://packages.clickhouse.com/deb/stable stable Release» не содержит файла Release. N: Обновление из этого репозитория нельзя выполнить безопасным способом, поэтому по умолчанию он отключён. N: Информацию о создании репозитория и настройках пользователя смотрите в справочной странице apt-secure(8). 
....
