### PR TITLE
Исправление REST API URL для обмена JWT на IAM токен

### DIFF
--- a/ru/iam/operations/iam-token/create-for-sa.md
+++ b/ru/iam/operations/iam-token/create-for-sa.md
@@ -505,15 +505,15 @@ yc iam create-token
 
 - API
 
-  Чтобы получить IAM-токен, воспользуйтесь методом REST API [createForServiceAccount](../../api-ref/IamToken/createForServiceAccount.md) для ресурса [IamToken](../../api-ref/IamToken/index.md) или вызовом gRPC API [IamTokenService/CreateForServiceAccount](../../api-ref/grpc/iam_token_service.md#CreateForServiceAccount).
+  Чтобы получить IAM-токен, воспользуйтесь методом REST API [create](../../api-ref/IamToken/create.md) для ресурса [IamToken](../../api-ref/IamToken/index.md) или вызовом gRPC API [IamTokenService/CreateForServiceAccount](../../api-ref/grpc/iam_token_service.md#CreateForServiceAccount).
 
-  Пример запроса с помощью cURL для метода REST API `createForServiceAccount`:
+  Пример запроса с помощью cURL для метода REST API `create`:
 
   ```curl
   curl -X POST \
       -H 'Content-Type: application/json' \
       -d '{"jwt": "<SIGNED_JWT>"}' \
-      https://iam.{{ api-host }}/iam/v1/tokens:createForServiceAccount
+      https://iam.{{ api-host }}/iam/v1/tokens
   ```
 
   Где `<SIGNED_JWT>` — токен в формате JWT, полученный на предыдущем шаге.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:

В примере API пункта ["Обменять JWT на IAM-токен"](https://cloud.yandex.ru/docs/iam/operations/iam-token/create-for-sa#get-iam-token) указан некорректный URL на REST API: jwt принимается только методом [IamToken.create](https://cloud.yandex.ru/docs/iam/api-ref/IamToken/create), а не [IamToken.createForServiceAccount](https://cloud.yandex.ru/docs/iam/api-ref/IamToken/createForServiceAccount).