### PR TITLE
Fix typo in Python exampe

### DIFF
--- a/ru/serverless-containers/quickstart/container.md
+++ b/ru/serverless-containers/quickstart/container.md
@@ -73,7 +73,7 @@ Docker-образ — исполняемый пакет, который соде
         return text("Hello!")
 
     if __name__ == "__main__":
-        app.run(host='0.0.0.0', port=os.environ['PORT'], motd=False, access_log=False)
+        app.run(host='0.0.0.0', port=int(os.environ['PORT']), motd=False, access_log=False)
     ```
 
     **Dockerfile**


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes: fix typo in Python example. Sanic app requires int value of port. Otherwise, exception is raised. See here https://github.com/sanic-org/sanic/blob/main/sanic/mixins/startup.py#L114
