### PR TITLE
Неверное отображение ssh-authorized-keys

### DIFF
--- a/ru/compute/concepts/vm-metadata.md
+++ b/ru/compute/concepts/vm-metadata.md
@@ -131,7 +131,7 @@
     {% include [user-data](../../_includes/compute/user-data.md) %}
 
     Чтобы передать эти данные в запросе, замените переносы строки символом `\n`:
-
+`Комментарий для коммита. Ошибка в блоке ниже:`
     ```json
     "metadata": {
       "user-data": "#cloud-config\nusers:\n  - name: user\n    groups: sudo\n    shell: /bin/bash\n    sudo: ['ALL=(ALL) NOPASSWD:ALL']\n    ssh-authorized-keys:\n      - ssh-ed25519 AAAAB3Nza......OjbSMRX user@example.com\n      - ssh-ed25519 AAAAB3Nza......Pu00jRN user@desktop"


### PR DESCRIPTION
Неверное отображение ssh-authorized-keys в русской версии документации.

В [рус. версии](https://cloud.yandex.ru/docs/compute/concepts/vm-metadata#keys-processed-in-public-images)
```
ssh_authorized_keys
```
В [англ. версии](https://cloud.yandex.com/en-ru/docs/compute/concepts/vm-metadata#keys-processed-in-public-images)
```
ssh-authorized-keys
```
----
А самое забавное в том, что здесь на GitHub'е всё верно. Блок строк 135-137. Оставил комментарий для коммита.

Рабочий вариант `ssh-authorized-keys`.