### PR TITLE
Update clickhouse terraform example

### DIFF
--- a/en/_tutorials/trails-logs-analysis.md
+++ b/en/_tutorials/trails-logs-analysis.md
@@ -273,8 +273,8 @@ The infrastructure support cost includes:
        }
 
        access {
-         datalens     = true
-         datatransfer = true
+         data_lens     = true
+         data_transfer = true
        }
      }
      ```

--- a/ru/_tutorials/trails-logs-analysis.md
+++ b/ru/_tutorials/trails-logs-analysis.md
@@ -273,8 +273,8 @@
        }
 
        access {
-         datalens     = true
-         datatransfer = true
+         data_lens     = true
+         data_transfer = true
        }
      }
      ```


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
Обновление содержит исправленную версию параметров для примера с tf.
```
│ Error: Unsupported argument
│
│ An argument named "datalens" is not expected here. Did you mean "data_lens"?
╵
╷
│ Error: Unsupported argument
│ 
│ An argument named "datatransfer" is not expected here. Did you mean "data_transfer"?
```
Согласно документации, данные параметры должны быть указаны с нижним подчеркиванием:
https://registry.tfpla.net/providers/yandex-cloud/yandex/latest/docs/resources/mdb_clickhouse_cluster#access

[data_lens](https://registry.tfpla.net/providers/yandex-cloud/yandex/latest/docs/resources/mdb_clickhouse_cluster#data_lens) - (Optional) Allow access for DataLens. Can be either true or false.

[data_transfer](https://registry.tfpla.net/providers/yandex-cloud/yandex/latest/docs/resources/mdb_clickhouse_cluster#data_transfer) - (Optional) Allow access for DataTransfer. Can be either true or false.

