### PR TITLE
Get rid of timestamp in logging example

### DIFF
--- a/en/_includes/logging/write-logs.md
+++ b/en/_includes/logging/write-logs.md
@@ -14,7 +14,6 @@
         yc logging write \
           --group-name=default \
           --message="My message" \
-          --timestamp="2023-06-08T19:10:40.000Z" \
           --level=INFO \
           --json-payload='{"request_id": "1234"}'
         ```
@@ -23,7 +22,6 @@
         yc logging write ^
           --group-name=default ^
           --message="My message" ^
-          --timestamp="2023-06-08T19:10:40.000Z" ^
           --level=INFO ^
           --json-payload="{"request_id": "1234"}"
         ```
@@ -32,7 +30,6 @@
         yc logging write `
           --group-name=default `
           --message="My message" `
-          --timestamp="2023-06-08T19:10:40.000Z" `
           --level=INFO `
           --json-payload='"{ \"request_id\": \"1234\" }"'
         ```
@@ -43,7 +40,6 @@
 
       * `--group-name`: Name of the log group to add records to. If this parameter is not specified, records are added to the [default log group](../../logging/concepts/log-group.md) in the current folder.
       * `--message`: Message.
-      * `--timestamp`: Time when the record is sent.
       * `--level`: Logging level.
       * `--json-payload`: Additional information in JSON format.
 

--- a/ru/_includes/logging/write-logs.md
+++ b/ru/_includes/logging/write-logs.md
@@ -14,7 +14,6 @@
         yc logging write \
           --group-name=default \
           --message="My message" \
-          --timestamp="2023-06-08T19:10:40.000Z" \
           --level=INFO \
           --json-payload='{"request_id": "1234"}'
         ```
@@ -23,7 +22,6 @@
         yc logging write ^
           --group-name=default ^
           --message="My message" ^
-          --timestamp="2023-06-08T19:10:40.000Z" ^
           --level=INFO ^
           --json-payload="{"request_id": "1234"}"
         ```
@@ -32,7 +30,6 @@
         yc logging write `
           --group-name=default `
           --message="My message" `
-          --timestamp="2023-06-08T19:10:40.000Z" `
           --level=INFO `
           --json-payload='"{ \"request_id\": \"1234\" }"'
         ```
@@ -43,7 +40,6 @@
 
         * `--group-name` — имя лог-группы, в которую вы хотите добавить записи. Если параметр не указан, записи добавляются в [лог-группу по умолчанию](../../logging/concepts/log-group.md) текущего каталога.
         * `--message` — сообщение.
-        * `--timestamp` — время отправки записи.
         * `--level` — уровень логирования.
         * `--json-payload` — дополнительная информация в формате JSON.
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
If timestamp date is after current date it is impossible to write logs to cloud logging. Get rid of timestamp variable in docs to prevent confusing