### PR TITLE
Edited function-invoke.md, detailing "Content-type"

### DIFF
--- a/en/functions/concepts/function-invoke.md
+++ b/en/functions/concepts/function-invoke.md
@@ -85,7 +85,7 @@ Where:
 
    {% note info %}
 
-   If the function is called with the `Content-Type: application/json` header, the contents of `body` stays in the original format (parameter value `isBase64Encoded`: false).
+   If the function is called with the `Content-Type: application/json` header (exactly identical, without extensions like `application/json; charset=utf-8`), the contents of `body` stays in the original format (parameter value `isBase64Encoded`: false).
 
    {% endnote %}
 

--- a/ru/functions/concepts/function-invoke.md
+++ b/ru/functions/concepts/function-invoke.md
@@ -96,7 +96,7 @@ JSON-структура запроса:
 
     {% note info %}
     
-    Если функция вызывается с заголовком `Content-Type: application/json`, то содержимое `body` останется в исходном формате (значение параметра `isBase64Encoded: false`).
+    Если функция вызывается с заголовком `Content-Type: application/json` (именно идентичным, без расширений вроде `application/json; charset=utf-8`), то содержимое `body` останется в исходном формате (значение параметра `isBase64Encoded: false`).
     
     {% endnote %}
     


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
Edited function-invoke.md, detailing "Content-type"

From the [Content-type docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type) it is clear that we can write `Content-type: application/json` as well as `Content-type: application/json; charset=utf-8`.

On real-world yandex cloud functions `Content-type: application/json; charset=utf-8` works in unexpected manner and bahaviour is different from  `Content-type: application/json`. IMHO this detail MUST be stated in documentation files.