### PR TITLE
Исправление ошибки создания docker-образа

### DIFF
--- a/ru/serverless-containers/quickstart/container.md
+++ b/ru/serverless-containers/quickstart/container.md
@@ -125,7 +125,7 @@ Docker-образ — исполняемый пакет, который соде
 
     WORKDIR /app
     ADD index.go .
-    RUN go build -a -tags netgo -ldflags '-w -extldflags "-static"' -o server-app *.go
+    RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -tags netgo -ldflags '-w -extldflags "-static"' -o server-app *.go
 
     FROM scratch
     COPY --from=build /app/server-app /server-app


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
Собирая docker-образ для go по вашей инструкции на macbook c процессором arm, возникла ошибка из-за несоответствия характеристик с указанными здесь https://cloud.yandex.ru/docs/serverless-containers/concepts/runtime. Данные флаги исправляют ошибку.
