### PR TITLE
delete 1.22 k8s-versions-release-channels

### DIFF
--- a/ru/presets.yaml
+++ b/ru/presets.yaml
@@ -785,9 +785,9 @@ default:
     https://stat.ripe.net/widget/announced-prefixes#w.resource%3DAS200350%26w.min_peers_seeing%3D0
   k8s-api-link: >-
     https://v1-22.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/
-  k8s-versions-rapid: 1.22, 1.23, 1.24, 1.25, 1.26, 1.27
-  k8s-versions-regular: 1.22, 1.23, 1.24
-  k8s-versions-stable: 1.22, 1.23, 1.24
+  k8s-versions-rapid: 1.23, 1.24, 1.25, 1.26, 1.27
+  k8s-versions-regular: 1.23, 1.24
+  k8s-versions-stable: 1.23, 1.24
   cic-bgp-asn: 200350
   cic-pbc-subnet: 178.210.118.46/31
   cic-pbc-subnet-client: 178.210.118.46


### PR DESCRIPTION
Update k8s-versions-release-channels: https://mks.api.cloud.yandex.net/managed-kubernetes/v1/versions

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes: delete deprecated 1.22 version k8s-versions-release-channels in presets.yaml. Source: https://mks.api.cloud.yandex.net/managed-kubernetes/v1/versions.
