### PR TITLE
Update create-static-conf.md

### DIFF
--- a/en/managed-kubernetes/operations/connect/create-static-conf.md
+++ b/en/managed-kubernetes/operations/connect/create-static-conf.md
@@ -126,6 +126,17 @@ Create a `ServiceAccount` object to interact with the {{ k8s }} API inside the {
    - kind: ServiceAccount
      name: admin-user
      namespace: kube-system
+   ---
+   apiVersion: v1
+   kind: Secret
+   type: kubernetes.io/service-account-token
+   metadata:
+     name: admin-user-token
+     namespace: kube-system
+     annotations:
+       kubernetes.io/service-account.name: "admin-user"
+
+
    ```
 
 1. Create a `ServiceAccount` object.
@@ -150,7 +161,7 @@ The token is required for `ServiceAccount` authentication in the {{ k8s }} clust
 
   ```bash
   SA_TOKEN=$(kubectl -n kube-system get secret $(kubectl -n kube-system get secret | \
-    grep admin-user | \
+    grep admin-user-token | \
     awk '{print $1}') -o json | \
     jq -r .data.token | \
     base64 --d)

--- a/ru/managed-kubernetes/operations/connect/create-static-conf.md
+++ b/ru/managed-kubernetes/operations/connect/create-static-conf.md
@@ -129,11 +129,12 @@
    ---
    apiVersion: v1
    kind: Secret
+   type: kubernetes.io/service-account-token
    metadata:
      name: admin-user-token
+     namespace: kube-system
      annotations:
-       kubernetes.io/service-account.name: admin-user
-   type: kubernetes.io/service-account-token
+       kubernetes.io/service-account.name: "admin-user"
    ```
 
 1. Создайте объект `ServiceAccount`:

--- a/ru/managed-kubernetes/operations/connect/create-static-conf.md
+++ b/ru/managed-kubernetes/operations/connect/create-static-conf.md
@@ -159,7 +159,7 @@
 
   ```bash
   SA_TOKEN=$(kubectl -n kube-system get secret $(kubectl -n kube-system get secret | \
-    grep admin-user | \
+    grep admin-user-token | \
     awk '{print $1}') -o json | \
     jq -r .data.token | \
     base64 --d)


### PR DESCRIPTION
почему-то отрабатывает создание секрета только с такой конфигой

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:

Hosts:
https://server-yfm.website.yandexcloud.net/server-yfm-e3d7bf33-0fd7-427e-bd4b-dc50b5670efb/ru/managed-kubernetes/operations/connect/create-static-conf.html
https://server-yfm.website.yandexcloud.net/server-yfm-e3d7bf33-0fd7-427e-bd4b-dc50b5670efb/en/managed-kubernetes/operations/connect/create-static-conf.html
Builds are successful.
