### PR TITLE
Change license of terraform

### DIFF
--- a/en/_tutorials/terraform-definition.md
+++ b/en/_tutorials/terraform-definition.md
@@ -1,4 +1,4 @@
-With [{{ TF }}](https://www.terraform.io/), you can quickly create a cloud infrastructure in {{ yandex-cloud }} and manage it using configuration files. They store the infrastructure description in HashiCorp Configuration Language (HCL). {{ TF }} and its providers are distributed under the [Mozilla Public License](https://github.com/hashicorp/terraform/blob/main/LICENSE).
+With [{{ TF }}](https://www.terraform.io/), you can quickly create a cloud infrastructure in {{ yandex-cloud }} and manage it using configuration files. They store the infrastructure description in HashiCorp Configuration Language (HCL). {{ TF }} and its providers are distributed under the [Business Source License](https://github.com/hashicorp/terraform/blob/main/LICENSE).
 
 For more information about the provider resources, see the documentation on the [{{ TF }}](https://www.terraform.io/docs/providers/yandex/index.html) website or [mirror website]({{ tf-docs-link }}).
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:

Terraform have changed the license recently, the documentation is not up to date with it