### PR TITLE
double aws-v1-http-endpoint setting definition

### DIFF
--- a/en/compute/operations/vm-info/get-info.md
+++ b/en/compute/operations/vm-info/get-info.md
@@ -185,7 +185,7 @@ You can set up metadata service parameters when creating or updating VMs.
 
 You can use the following settings:
 * `aws-v1-http-endpoint` provides access to metadata using AWS format (IMDSv1). Acceptable values: `enabled`, `disabled`.
-* `aws-v1-http-endpoint` provides access to {{ iam-name }} credentials using AWS format (IMDSv1). Acceptable values: `enabled`, `disabled`.
+* `aws-v1-http-token` provides access to {{ iam-name }} credentials using AWS format (IMDSv1). Acceptable values: `enabled`, `disabled`.
 
    {% note info %}
 


### PR DESCRIPTION
the second setting should be aws-v1-http-token

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:

Just typo in setting name.