### PR TITLE
fix: get autoaction request method

### DIFF
--- a/en/tracker/concepts/queues/get-autoaction.md
+++ b/en/tracker/concepts/queues/get-autoaction.md
@@ -12,7 +12,7 @@ Before making the request, [get permission to access the API](../access.md).
 To get auto action parameters, use the HTTP `GET` request method.
 
 ```json
-POST /{{ ver }}/queues/<queue-id>/autoactions/<autoaction-id>
+GET /{{ ver }}/queues/<queue-id>/autoactions/<autoaction-id>
 Host: {{ host }}
 Authorization: OAuth <OAuth token>
 {{ org-id }}

--- a/ru/tracker/concepts/queues/get-autoaction.md
+++ b/ru/tracker/concepts/queues/get-autoaction.md
@@ -12,7 +12,7 @@ sourcePath: ru/tracker/api-ref/concepts/queues/get-autoaction.md
 Чтобы получить параметры автодействия, используйте HTTP-запрос с методом `GET`. 
 
 ```json
-POST /{{ ver }}/queues/<queue-id>/autoactions/<autoaction-id>
+GET /{{ ver }}/queues/<queue-id>/autoactions/<autoaction-id>
 Host: {{ host }}
 Authorization: OAuth <OAuth-токен>
 {{ org-id }}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
According to docs method must be GET (not POST) in request for getting autoaction.
