### PR TITLE
Update gitlab-runner.md

### DIFF
--- a/en/managed-kubernetes/operations/applications/gitlab-runner.md
+++ b/en/managed-kubernetes/operations/applications/gitlab-runner.md
@@ -58,7 +58,7 @@
      --namespace <namespace> \
      --create-namespace \
      --set gitlabDomain=<VM_public_IP_or_{{ GL }}_instance_FQDN> \
-     --set runnerToken=<previously_retrieved_registration_token> \
+     --set runnerRegistrationToken=<previously_retrieved_registration_token> \
      gitlab-runner ./gitlab-runner/
    ```
 

--- a/ru/managed-kubernetes/operations/applications/gitlab-runner.md
+++ b/ru/managed-kubernetes/operations/applications/gitlab-runner.md
@@ -58,7 +58,7 @@
      --namespace <пространство_имен> \
      --create-namespace \
      --set gitlabDomain=<публичный_IP-адрес_ВМ_или_FQDN_инстанса_{{ GL }}> \
-     --set runnerToken=<ранее_полученный_регистрационный_токен> \
+     --set runnerRegistrationToken=<ранее_полученный_регистрационный_токен> \
      gitlab-runner ./gitlab-runner/
    ```
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
https://cloud.yandex.ru/ru/docs/managed-kubernetes/operations/applications/gitlab-runner
Неверное имя параметра `runnerRegistrationToken` при создании раннера с помощью helm