### PR TITLE
Put route table name in quotes at create-nat-gateway.md

### DIFF
--- a/ru/vpc/operations/create-nat-gateway.md
+++ b/ru/vpc/operations/create-nat-gateway.md
@@ -120,7 +120,7 @@ description: "Следуя данной инструкции, вы сможет�
   }
 
   resource "yandex_vpc_route_table" "rt" {
-    name       = test-route-table
+    name       = "test-route-table"
     network_id = "<идентификатор_сети>"
 
     static_route {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
To validate terraform code for "yandex_vpc_route_table" it's name has to be in quotes