### PR TITLE
Update terraform-prepare-plan-linux.md

### DIFF
--- a/ru/_tutorials/terraform-prepare-plan-linux.md
+++ b/ru/_tutorials/terraform-prepare-plan-linux.md
@@ -41,7 +41,7 @@
      }
 
      boot_disk {
-       image_id = yandex_compute_disk.boot-disk-1.id
+       disk_id = yandex_compute_disk.boot-disk-1.id
      }
 
      network_interface {
@@ -63,7 +63,7 @@
      }
 
      boot_disk {
-       image_id = yandex_compute_disk.boot-disk-2.id
+       disk_id = yandex_compute_disk.boot-disk-2.id
      }
 
      network_interface {


### PR DESCRIPTION
Error: Unsupported argument
│
│   on main.tf line 32, in resource "yandex_compute_instance" "vm-1":
│   32:     image_id = yandex_compute_disk.boot-disk-1.id
│
│ An argument named "image_id" is not expected here.

Terraform v1.7.2

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
