### PR TITLE
Update terraform-prepare-plan-linux.md

### DIFF
--- a/ru/_tutorials/terraform-prepare-plan-linux.md
+++ b/ru/_tutorials/terraform-prepare-plan-linux.md
@@ -41,7 +41,7 @@
      }
 
      boot_disk {
-       image_id = yandex_compute_disk.boot-disk-1.id
+       disk_id = yandex_compute_disk.boot-disk-1.id
      }
 
      network_interface {
@@ -63,7 +63,7 @@
      }
 
      boot_disk {
-       image_id = yandex_compute_disk.boot-disk-2.id
+       disk_id = yandex_compute_disk.boot-disk-2.id
      }
 
      network_interface {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
При создании инстанса ВМ в блоке boot_disk требуется указать disk_id, а не image_id (image_id указывается при создании инстанса диска).

Источник: https://terraform-provider.yandexcloud.net/Resources/compute_instance#argument-reference
