### PR TITLE
Update laravel.md

### DIFF
--- a/ru/message-queue/instruments/laravel.md
+++ b/ru/message-queue/instruments/laravel.md
@@ -151,18 +151,6 @@ export AWS_SECRET_ACCESS_KEY="<секретный ключ>"
    ],
    ```
 
-1. Добавьте в зависимости проекта пакет `aws/aws-sdk-php`:
-   
-   ```
-   composer require aws/aws-sdk-php
-   ```
-
-1. Обновите конфигурацию Composer:
-
-   ```
-   composer update
-   ```
-
 1. Выполните команду:
 
    ```


### PR DESCRIPTION
Laravel уже содержит необходимые инструменты для работы с очередями SQS.  Фактически, добавление этой зависимости приводит к неработоспособности кода примера, так как сервис игнорирует часть настроек и пытается обращаться к сервисам Amazon по URL вида: sqs.ru-central1.amazonaws.com.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
