### PR TITLE
Исправлены опечатки в описаниях кодов ответа HTTP.

### DIFF
--- a/ru/application-load-balancer/concepts/application-load-balancer.md
+++ b/ru/application-load-balancer/concepts/application-load-balancer.md
@@ -173,12 +173,12 @@
 * `403` — Forbidden
 * `404` — Not Found
 * `405` — Method Not Allowed
-* `406` — Not Aceptable
+* `406` — Not Acceptable
 * `407` — Proxy Authentication Required
 * `408` — Request Timeout
 * `409` — Conflict
 * `410` — Gone
-* `411` — Lenght Required
+* `411` — Length Required
 * `412` — Precondition Failed
 * `413` — Request Entity Too Large
 * `414` — Request-URI Too Long


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:

Corrected two typos in descriptions of HTTP response status codes, namely `406` and `411`.