### PR TITLE
feat(ru/en): added list of packages versions for Golang and NodeJS clients for YMQ

### DIFF
--- a/en/message-queue/instruments/golang.md
+++ b/en/message-queue/instruments/golang.md
@@ -6,6 +6,15 @@ Using the [AWS SDK for Golang](https://aws.amazon.com/sdk-for-go/), you can mana
 
 Install the AWS SDK for Golang by following the [instructions](https://aws.amazon.com/sdk-for-go/) on the official website.
 
+Starting with version sqs service `v1.26.0` AWS uses the JSON protocol for client interaction with services, instead of XML-based.
+Correct operation is possible when using the following package versions:
+```
+github.com/aws/aws-sdk-go-v2 v1.22.2
+github.com/aws/aws-sdk-go-v2/config v1.25.0
+github.com/aws/aws-sdk-go-v2/credentials v1.16.0
+github.com/aws/aws-sdk-go-v2/service/sqs v1.26.0
+```
+
 ## Before you start {#prepare}
 
 {% include [mq-http-api-preps](../_includes_service/mq-http-api-preps-sdk.md)%}

--- a/en/message-queue/instruments/node.md
+++ b/en/message-queue/instruments/node.md
@@ -6,6 +6,12 @@
 
 Install the AWS SDK for JavaScript in Node.js by following the [instructions](https://aws.amazon.com/sdk-for-node-js/) on the official site.
 
+Starting with version sqs service `3.446.0` AWS uses the JSON protocol for client interaction with services, instead of XML-based.
+Correct operation is possible only when using package versions up to `3.445.0` inclusive.
+```shell
+npm install @aws-sdk/client-sqs@3.445.0
+```
+
 ## Before you start {#prepare}
 
 {% include [mq-http-api-preps](../_includes_service/mq-http-api-preps-sdk.md)%}

--- a/ru/message-queue/instruments/golang.md
+++ b/ru/message-queue/instruments/golang.md
@@ -6,6 +6,15 @@
 
 Установите AWS SDK для Golang [по инструкции](https://aws.amazon.com/ru/sdk-for-go/) на официальном сайте.
 
+Начиная с версии sqs сервиса `v1.26.0` AWS использует протокол JSON для взаимодействия клиентов с сервисами, вместо XML-based.
+Корректная работа возможна, при использовании следующих версий пакетов:
+```
+github.com/aws/aws-sdk-go-v2 v1.22.2
+github.com/aws/aws-sdk-go-v2/config v1.25.0
+github.com/aws/aws-sdk-go-v2/credentials v1.16.0
+github.com/aws/aws-sdk-go-v2/service/sqs v1.26.0
+```
+
 ## Подготовка к работе {#prepare}
 
 {% include [mq-http-api-preps](../_includes_service/mq-http-api-preps-sdk.md)%}

--- a/ru/message-queue/instruments/node.md
+++ b/ru/message-queue/instruments/node.md
@@ -6,6 +6,12 @@
 
 Установите AWS SDK для JavaScript в Node.js [по инструкции](https://aws.amazon.com/ru/sdk-for-node-js/) на официальном сайте.
 
+Начиная с версии sqs сервиса `3.446.0` AWS использует протокол JSON для взаимодействия клиентов с сервисами, вместо XML-based.
+Корректная работа возможна, только при использовании версий пакета до `3.445.0` включительно.
+```shell
+npm install @aws-sdk/client-sqs@3.445.0
+```
+
 ## Подготовка к работе {#prepare}
 
 {% include [mq-http-api-preps](../_includes_service/mq-http-api-preps-sdk.md)%}


### PR DESCRIPTION
Description of changes:
- added list of packages versions for `aws-sdk-go-v2`
- added package version for `@aws-sdk/client-sqs`

В связи с переходом AWS на протокол JSON, для корректной работы клиентов SQS необходимо использовать предыдущие версии пакетов.

Due to AWS's transition to the JSON protocol, previous versions of packages must be used for SQS clients to function correctly.

Идентификатор `dn2fioplk559imdvrlpm`

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru