### PR TITLE
Fix b64encode() output for body parameter compatibility

### DIFF
--- a/ru/_includes/vision/base64-encode-command.md
+++ b/ru/_includes/vision/base64-encode-command.md
@@ -28,7 +28,7 @@
   # Создайте функцию, которая кодирует файл и возвращает результат.
   def encode_file(file):
     file_content = file.read()
-    return base64.b64encode(file_content)
+    return str(base64.b64encode(file_content))[2:-1]
   ```
   
 - Node.js {#node}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
This commit fixes an issue where the base64.b64encode(file_content) function was not producing output compatible with the requirements of the body parameter.