### PR TITLE
fix: Исправление небольшой опечатки в "Метрики и единицы измерения"

### DIFF
--- a/ru/_qa/monitoring/metrics-measure.md
+++ b/ru/_qa/monitoring/metrics-measure.md
@@ -17,7 +17,7 @@
 * [{{ mmy-full-name }}](../../managed-mysql/operations/monitoring.md).
 * [{{ mrd-full-name }}](../../managed-redis/operations/monitoring.md).
 
-Важные метрики выведены на сервисные дашборды каждого сервиса. Полных список метрик для каждого сервиса доступен в разделе **{{ ui-key.yacloud_monitoring.aside-navigation.menu-item.explorer.title }}**. Выгрузить полный список метрик можно по [инструкции](../../monitoring/operations/metric/list.md).
+Важные метрики выведены на сервисные дашборды каждого сервиса. Полный список метрик для каждого сервиса доступен в разделе **{{ ui-key.yacloud_monitoring.aside-navigation.menu-item.explorer.title }}**. Выгрузить полный список метрик можно по [инструкции](../../monitoring/operations/metric/list.md).
 
 #### Как настроить единицы измерения на графике? {#graph-units}
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
- Исправление небольшой опечатки в "Метрики и единицы измерения". Заменено "Полных" на "Полный"