### PR TITLE
Add wildcard to ssh systemd unit name

### DIFF
--- a/ru/compute/operations/serial-console/index.md
+++ b/ru/compute/operations/serial-console/index.md
@@ -116,7 +116,7 @@
 1. Перезапустите SSH-сервер:
 
    ```bash
-   sudo systemctl restart ssh
+   sudo systemctl restart ssh*
    ```
 
 #### Создайте пароль для пользователя Linux {#create-pass}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
Добавил в название systemd юнита wildcard, чтобы команду можно было выполнить в RPM-based дистрибутивах, так как там юнит называется sshd