### PR TITLE
Added info about dracut command for install virtio drivers

### DIFF
--- a/ru/compute/operations/image-create/custom-image.md
+++ b/ru/compute/operations/image-create/custom-image.md
@@ -76,6 +76,12 @@
        sudo mkinitrd -f --with=virtio_blk --with=virtio_net --with=virtio_pci --with=virtiofs /boot/initramfs-$(uname -r).img $(uname -r)
        ```
 
+     * Если появилась ошибка `Command 'mkinitrd' not found`, то драйверы нужно установить при помощи утилиты `dracut`:
+
+       ```sh
+       sudo dracut --force --add-drivers "virtio_blk virtio_net virtio_pci virtiofs" /boot/initramfs-$(uname -r).img $(uname -r)
+       ```
+
        После этого перезапустите ОС и проверьте, что драйверы появились в файле `initramfs` и загрузились:
 
        ```sh

--- a/ru/compute/operations/image-create/custom-image.md
+++ b/ru/compute/operations/image-create/custom-image.md
@@ -76,10 +76,10 @@
        sudo mkinitrd -f --with=virtio_blk --with=virtio_net --with=virtio_pci --with=virtiofs /boot/initramfs-$(uname -r).img $(uname -r)
        ```
 
-     * Если появилась ошибка `Command 'mkinitrd' not found`, то драйверы нужно установить при помощи утилиты `dracut`:
+       Если на экране появилась ошибка `Command 'mkinitrd' not found`, установите драйверы с помощью утилиты `dracut`:
 
        ```sh
-       sudo dracut --force --add-drivers "virtio_blk virtio_net virtio_pci virtiofs" /boot/initramfs-$(uname -r).img $(uname -r)
+       sudo dracut -f --add-drivers "virtio_blk virtio_net virtio_pci virtiofs" /boot/initramfs-$(uname -r).img $(uname -r)
        ```
 
        После этого перезапустите ОС и проверьте, что драйверы появились в файле `initramfs` и загрузились:


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
Добавил информацию об установке драйверов при помощи команды `dracut`
Это актуально для новых RPM дистрибутивов, в частности RHEL 9 и RED OS 8
Ссылка на issue в RHEL 9:
https://access.redhat.com/solutions/7016117