### PR TITLE
fix(ru/en): fix body data type in API Gateway HTTP request in golang/handler.md

### DIFF
--- a/en/functions/lang/golang/handler.md
+++ b/en/functions/lang/golang/handler.md
@@ -305,7 +305,7 @@ type APIGatewayRequest struct {
 	Parameters           map[string]string   `json:"parameters"`
 	MultiValueParameters map[string][]string `json:"multiValueParameters"`
 
-	Body            []byte `json:"body"`
+	Body            string `json:"body"`
 	IsBase64Encoded bool   `json:"isBase64Encoded,omitempty"`
 
 	RequestContext interface{} `json:"requestContext"`

--- a/ru/functions/lang/golang/handler.md
+++ b/ru/functions/lang/golang/handler.md
@@ -305,7 +305,7 @@ type APIGatewayRequest struct {
 	Parameters           map[string]string   `json:"parameters"`
 	MultiValueParameters map[string][]string `json:"multiValueParameters"`
 
-	Body            []byte `json:"body"`
+	Body            string `json:"body"`
 	IsBase64Encoded bool   `json:"isBase64Encoded,omitempty"`
 
 	RequestContext interface{} `json:"requestContext"`


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:

поменял тип с []byte на string в Разборе HTTP-запроса за API Gateway, чтобы максимально соответствовать структуре AWS API Gateway: https://github.com/aws/aws-lambda-go/blob/main/events/apigw.go#L17

к тому же в https://yandex.cloud/ru/docs/functions/concepts/function-invoke#request указывается, что: 

> body — содержимое запроса в виде **строки**

если оставлять []byte, то это может выливаться для тех, кто попробует передать "Content-Type""application/json" в ошибку "illegal base64 data at input byte 0"