### PR TITLE
fix(ru/en): body data type in golang/handler.md

### DIFF
--- a/en/functions/lang/golang/handler.md
+++ b/en/functions/lang/golang/handler.md
@@ -305,7 +305,7 @@ type APIGatewayRequest struct {
 	Parameters           map[string]string   `json:"parameters"`
 	MultiValueParameters map[string][]string `json:"multiValueParameters"`
 
-	Body            []byte `json:"body"`
+	Body            string `json:"body"`
 	IsBase64Encoded bool   `json:"isBase64Encoded,omitempty"`
 
 	RequestContext interface{} `json:"requestContext"`
@@ -328,7 +328,7 @@ func Greet(ctx context.Context, event *APIGatewayRequest) (*APIGatewayResponse, 
 	req := &Request{}
 
 	// The request's event.Body field is converted to a Request object to get the passed name
-	if err := json.Unmarshal(event.Body, &req); err != nil {
+	if err := json.Unmarshal([]byte(event.Body), &req); err != nil {
 		return nil, fmt.Errorf("an error has occurred when parsing body: %v", err)
 	}
 

--- a/ru/functions/lang/golang/handler.md
+++ b/ru/functions/lang/golang/handler.md
@@ -305,7 +305,7 @@ type APIGatewayRequest struct {
 	Parameters           map[string]string   `json:"parameters"`
 	MultiValueParameters map[string][]string `json:"multiValueParameters"`
 
-	Body            []byte `json:"body"`
+	Body            string `json:"body"`
 	IsBase64Encoded bool   `json:"isBase64Encoded,omitempty"`
 
 	RequestContext interface{} `json:"requestContext"`
@@ -328,7 +328,7 @@ func Greet(ctx context.Context, event *APIGatewayRequest) (*APIGatewayResponse, 
 	req := &Request{}
 
 	// Поле event.Body запроса преобразуется в объект типа Request для получения переданного имени
-	if err := json.Unmarshal(event.Body, &req); err != nil {
+	if err := json.Unmarshal([]byte(event.Body), &req); err != nil {
 		return nil, fmt.Errorf("an error has occurred when parsing body: %v", err)
 	}
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:

пример с кодом на текущий момент не работает

поменял тип с []byte на string в Разборе HTTP-запроса за API Gateway, чтобы максимально соответствовать структуре AWS API Gateway: https://github.com/aws/aws-lambda-go/blob/main/events/apigw.go#L17

к тому же в https://yandex.cloud/ru/docs/functions/concepts/function-invoke#request указывается, что: 

> body — содержимое запроса в виде **строки**

если оставлять []byte, то это может выливаться в ошибку "illegal base64 data at input byte 0" для тех, кто попробует передать "Content-Type""application/json" 

