### PR TITLE
migrate to fluent-bit for cloud logging from vm

### DIFF
--- a/en/_tutorials/security/vm-fluent-bit-logging.md
+++ b/en/_tutorials/security/vm-fluent-bit-logging.md
@@ -248,35 +248,37 @@ To set up log transfer:
    sudo apt-get update
    ```
 
-1. Install the `td-agent-bit` package:
+1. Install the `fluent-bit` package:
 
    ```bash
-   sudo apt-get install td-agent-bit
+   sudo apt-get install fluent-bit
    ```
 
-1. Start `td-agent-bit`:
+1. Start `fluent-bit`:
 
    ```bash
-   sudo systemctl start td-agent-bit
+   sudo systemctl start fluent-bit
    ```
 
-1. Recheck the `td-agent-bit` service status, it should be active:
+1. Recheck the `fluent-bit` service status, it should be active:
 
    ```bash
-   systemctl status td-agent-bit
+   systemctl status fluent-bit
    ```
 
    Result:
 
    ```bash
-   ● td-agent-bit.service - TD Agent Bit
-        Loaded: loaded (/lib/systemd/system/td-agent-bit.service; disabled; vendor preset: enabled)
-        Active: active (running) since Wed 2022-02-02 12:09:11 UTC; 56s ago
-      Main PID: 7365 (td-agent-bit)
-         Tasks: 3 (limit: 2311)
-        Memory: 4.9M
-        CGroup: /system.slice/td-agent-bit.service
-                └─7365 /opt/td-agent-bit/bin/td-agent-bit -c /etc/td-agent-bit/td-agent-bit.conf
+    ● fluent-bit.service - Fluent Bit
+         Loaded: loaded (/lib/systemd/system/fluent-bit.service; disabled; vendor preset: enabled)
+         Active: active (running) since Tue 2024-04-30 09:00:58 UTC; 3h 35min ago
+           Docs: https://docs.fluentbit.io/manual/
+       Main PID: 589764 (fluent-bit)
+          Tasks: 9 (limit: 2219)
+         Memory: 18.8M
+            CPU: 2.543s
+         CGroup: /system.slice/fluent-bit.service
+                 └─589764 /opt/fluent-bit/bin/fluent-bit -c //etc/fluent-bit/fluent-bit.conf
    ```
 
 ## Enable the plugin {#connect-plugin}
@@ -291,28 +293,33 @@ To set up log transfer:
 
    ```bash
    cd fluent-bit-plugin-yandex/
-   export fluent_bit_version=1.8.6
+   export fluent_bit_version=3.0.3
+   export golang_version=1.22.2
    export plugin_version=dev
-   CGO_ENABLED=1 go build     -buildmode=c-shared \
+   CGO_ENABLED=1 go build -buildmode=c-shared \
      -o ./yc-logging.so \
      -ldflags "-X main.PluginVersion=${plugin_version}" \
      -ldflags "-X main.FluentBitVersion=${fluent_bit_version}"
    ```
 
-1. Compile the `yc-logging.so` library:
+   Where:
+   * `fluent_bit_version`: Version of installed `fluent-bit` package. To check it manually run `/opt/fluent-bit/bin/fluent-bit --version`.
+   * `golang_version`: Version of the Go compiler. To check it manually run `go version`.
+
+1. Copy the `yc-logging.so` to `fluent-bit` library folder:
 
    ```bash
-   sudo cp yc-logging.so /usr/lib/td-agent-bit/yc-logging.so
+   sudo cp yc-logging.so /usr/lib/fluent-bit/plugins/yc-logging.so
    ```
 
-1. To the `/etc/td-agent-bit/plugins.conf` file with plugin settings, add the path to the `yc-logging.so` library:
+1. To the `/etc/fluent-bit/plugins.conf` file with plugin settings, add the path to the `yc-logging.so` library:
 
    ```
    [PLUGINS]
-       Path /usr/lib/td-agent-bit/yc-logging.so
+       Path /usr/lib/fluent-bit/plugins/yc-logging.so
    ```
 
-1. To the `/etc/td-agent-bit/td-agent-bit.conf` file, add the `td-agent-bit` service settings:
+1. To the `/etc/fluent-bit/fluent-bit.conf` file, add the `fluent-bit` service settings:
 
 
    ```
@@ -336,10 +343,10 @@ To set up log transfer:
    * `folder_id`: [ID of the folder](../../resource-manager/operations/folder/get-id.md) to whose [default log group](../../logging/concepts/log-group.md) the logs will be sent.
    * `authorization`: Authorization settings. Specify `instance-service-account` to log in under the service account that you provided under **{{ ui-key.yacloud.compute.instances.create.section_access }}** when [creating a VM](#before-you-begin).
 
-1. Restart the `td-agent-bit` service:
+1. Restart the `fluent-bit` service:
 
    ```bash
-   sudo systemctl restart td-agent-bit
+   sudo systemctl restart fluent-bit
    ```
 
 ## View the logs {#read-logs}
@@ -348,7 +355,7 @@ To set up log transfer:
 
 - Management console {#console}
 
-   1. In the [management console]({{ link-console-main }}), go to the folder that you specified in the `td-agent-bit` service settings.
+   1. In the [management console]({{ link-console-main }}), go to the folder that you specified in the `fluent-bit` service settings.
    1. Select **{{ ui-key.yacloud.iam.folder.dashboard.label_logging }}**.
    1. Click the row with the `default` log group.
    1. Go to the **{{ ui-key.yacloud.common.logs }}** tab.
@@ -365,7 +372,7 @@ To set up log transfer:
    yc logging read --folder-id=<folder_ID>
    ```
 
-   Where `--folder-id` is the folder ID specified in the `td-agent-bit` service settings.
+   Where `--folder-id` is the folder ID specified in the `fluent-bit` service settings.
 
 - API {#api}
 

--- a/ru/_tutorials/security/vm-fluent-bit-logging.md
+++ b/ru/_tutorials/security/vm-fluent-bit-logging.md
@@ -248,36 +248,38 @@
     sudo apt-get update
     ```
 
-1. Установите пакет `td-agent-bit`:
+1. Установите пакет `fluent-bit`:
 
     ```bash
-    sudo apt-get install td-agent-bit
+    sudo apt-get install fluent-bit
     ```
 
-1. Запустите сервис `td-agent-bit`:
+1. Запустите сервис `fluent-bit`:
 
     ```bash
-    sudo systemctl start td-agent-bit
+    sudo systemctl start fluent-bit
     ```
 
-1. Проверьте статус сервиса `td-agent-bit`, он должен быть активен:
+1. Проверьте статус сервиса `fluent-bit`, он должен быть активен:
 
     ```bash
-    systemctl status td-agent-bit
+    systemctl status fluent-bit
     ```
 
     Результат:
 
     ```bash
-    ● td-agent-bit.service - TD Agent Bit
-         Loaded: loaded (/lib/systemd/system/td-agent-bit.service; disabled; vendor preset: enabled)
-         Active: active (running) since Wed 2022-02-02 12:09:11 UTC; 56s ago
-       Main PID: 7365 (td-agent-bit)
-          Tasks: 3 (limit: 2311)
-         Memory: 4.9M
-         CGroup: /system.slice/td-agent-bit.service
-                 └─7365 /opt/td-agent-bit/bin/td-agent-bit -c /etc/td-agent-bit/td-agent-bit.conf
-    ```
+    ● fluent-bit.service - Fluent Bit
+         Loaded: loaded (/lib/systemd/system/fluent-bit.service; disabled; vendor preset: enabled)
+         Active: active (running) since Tue 2024-04-30 09:00:58 UTC; 3h 35min ago
+           Docs: https://docs.fluentbit.io/manual/
+       Main PID: 589764 (fluent-bit)
+          Tasks: 9 (limit: 2219)
+         Memory: 18.8M
+            CPU: 2.543s
+         CGroup: /system.slice/fluent-bit.service
+                 └─589764 /opt/fluent-bit/bin/fluent-bit -c //etc/fluent-bit/fluent-bit.conf
+   ```
 
 ## Подключите плагин {#connect-plugin}
 
@@ -291,28 +293,33 @@
 
     ```bash
     cd fluent-bit-plugin-yandex/
-    export fluent_bit_version=1.8.6
+    export fluent_bit_version=3.0.3
+    export golang_version=1.22.2
     export plugin_version=dev
-    CGO_ENABLED=1 go build     -buildmode=c-shared \
-      -o ./yc-logging.so \
-      -ldflags "-X main.PluginVersion=${plugin_version}" \
-      -ldflags "-X main.FluentBitVersion=${fluent_bit_version}"
-    ```
+    CGO_ENABLED=1 go build -buildmode=c-shared \
+        -o ./yc-logging.so \
+        -ldflags "-X main.PluginVersion=${plugin_version}" \
+        -ldflags "-X main.FluentBitVersion=${fluent_bit_version}"
+   ```
 
-1. Скопируйте библиотеку `yc-logging.so`:
+   Где:
+   * `fluent_bit_version`: Версия пакета `fluent-bit`. Для проверки версии воспользуйтесь командой `/opt/fluent-bit/bin/fluent-bit --version`.
+   * `golang_version`: Версия компилятора Go. Для проверки версии воспользуйтесь командой `go version`.
+
+1. Скопируйте библиотеку `yc-logging.so` в директорию библиотек `fluent-bit`:
 
     ```bash
-    sudo cp yc-logging.so /usr/lib/td-agent-bit/yc-logging.so
+    sudo cp yc-logging.so /usr/lib/fluent-bit/plugins/yc-logging.so
     ```
 
-1. Добавьте в файл с настройками плагинов `/etc/td-agent-bit/plugins.conf` путь до библиотеки `yc-logging.so`:
+1. Добавьте в файл с настройками плагинов `/etc/fluent-bit/plugins.conf` путь до библиотеки `yc-logging.so`:
 
     ```
     [PLUGINS]
-        Path /usr/lib/td-agent-bit/yc-logging.so
+        Path /usr/lib/fluent-bit/plugins/yc-logging.so
     ```
 
-1. Добавьте в файл `/etc/td-agent-bit/td-agent-bit.conf` настройки сервиса `td-agent-bit`:
+1. Добавьте в файл `/etc/fluent-bit/fluent-bit.conf` настройки сервиса `fluent-bit`:
 
 
     ```
@@ -336,10 +343,10 @@
     * `folder_id` — [идентификатор каталога](../../resource-manager/operations/folder/get-id.md), в [лог-группу по умолчанию](../../logging/concepts/log-group.md) которого будут передаваться логи.
     * `authorization` — настройки авторизации. Укажите `instance-service-account`, чтобы авторизоваться от имени сервисного аккаунта, который указали в блоке **{{ ui-key.yacloud.compute.instances.create.section_access }}** при [создании ВМ](#before-you-begin).
 
-1. Перезапустите сервис `td-agent-bit`:
+1. Перезапустите сервис `fluent-bit`:
 
     ```bash
-    sudo systemctl restart td-agent-bit
+    sudo systemctl restart fluent-bit
     ```
 
 ## Посмотрите логи {#read-logs}
@@ -348,7 +355,7 @@
 
 - Консоль управления {#console}
 
-    1.  В [консоли  управления]({{ link-console-main }}) перейдите в каталог, который указали в настройках сервиса `td-agent-bit`.
+    1.  В [консоли  управления]({{ link-console-main }}) перейдите в каталог, который указали в настройках сервиса `fluent-bit`.
     1. Выберите сервис **{{ ui-key.yacloud.iam.folder.dashboard.label_logging }}**.
     1. Нажмите на строку c лог-группой по умолчанию `default`.
     1. Перейдите на вкладку **{{ ui-key.yacloud.common.logs }}**.
@@ -365,7 +372,7 @@
     yc logging read --folder-id=<идентификатор_каталога>
     ```
 
-    Где `--folder-id` — идентификатор каталога, который указан в настройках сервиса `td-agent-bit`.
+    Где `--folder-id` — идентификатор каталога, который указан в настройках сервиса `fluent-bit`.
 
 - API {#api}
 

--- a/ru/_tutorials/security/vm-fluent-bit-logging.md
+++ b/ru/_tutorials/security/vm-fluent-bit-logging.md
@@ -303,8 +303,8 @@
    ```
 
    Где:
-   * `fluent_bit_version`: Версия пакета `fluent-bit`. Для проверки версии воспользуйтесь командой `/opt/fluent-bit/bin/fluent-bit --version`.
-   * `golang_version`: Версия компилятора Go. Для проверки версии воспользуйтесь командой `go version`.
+   * `fluent_bit_version` — версия пакета `fluent-bit`. Для проверки версии воспользуйтесь командой `/opt/fluent-bit/bin/fluent-bit --version`.
+   * `golang_version` — версия компилятора Go. Для проверки версии воспользуйтесь командой `go version`.
 
 1. Скопируйте библиотеку `yc-logging.so` в директорию библиотек `fluent-bit`:
 

--- a/ru/_tutorials/security/vm-fluent-bit-logging.md
+++ b/ru/_tutorials/security/vm-fluent-bit-logging.md
@@ -137,8 +137,11 @@
 
 1. Создайте виртуальную среду и установите необходимые зависимости:
 
+   ```bash
+   sudo apt install python3-pip python3.8-venv
+   ```
+
     ```bash
-    sudo apt install python3-pip python3.8-venv
     python3 -m venv venv
     source venv/bin/activate
     pip3 install systemd-logging
@@ -289,22 +292,37 @@
     git clone https://github.com/yandex-cloud/fluent-bit-plugin-yandex.git
     ```
 
-1. Скомпилируйте библиотеку `yc-logging.so`:
+1. Запишите в переменные окружения версии пакетов:
 
     ```bash
     cd fluent-bit-plugin-yandex/
     export fluent_bit_version=3.0.3
     export golang_version=1.22.2
     export plugin_version=dev
-    CGO_ENABLED=1 go build -buildmode=c-shared \
-        -o ./yc-logging.so \
-        -ldflags "-X main.PluginVersion=${plugin_version}" \
-        -ldflags "-X main.FluentBitVersion=${fluent_bit_version}"
    ```
 
    Где:
    * `fluent_bit_version` — версия пакета `fluent-bit`. Для проверки версии воспользуйтесь командой `/opt/fluent-bit/bin/fluent-bit --version`.
    * `golang_version` — версия компилятора Go. Для проверки версии воспользуйтесь командой `go version`.
+
+1. Выйдите из виртуального окружения Python и назначьте права на директорию с плагином:
+
+   ```bash
+    deactivate
+    ```
+
+   ```bash
+    sudo chown -R $USER:$USER /fluent-bit-plugin-yandex
+    ```
+   
+1. Скомпилируйте библиотеку `yc-logging.so`:
+
+    ```bash
+    CGO_ENABLED=1 go build -buildmode=c-shared \
+        -o ./yc-logging.so \
+        -ldflags "-X main.PluginVersion=${plugin_version}" \
+        -ldflags "-X main.FluentBitVersion=${fluent_bit_version}"
+   ```
 
 1. Скопируйте библиотеку `yc-logging.so` в директорию библиотек `fluent-bit`:
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
Согласно текущей документации по передаче логов с виртуальной машины в Cloud Logging используется пакет `td-agent-bit`, который с 2022 года считается deprecated и не обновляется. В нем также отсутствуют фичи с полноценной обработкой multiline логов, что может вызывать проблемы у людей, которые настраивают поставку логов. Сам столкнулся с этой проблемой, после чего и пришлось мигрировать со старого пакета на новый `fluent-bit`.

Обновил документацию по использованию пакета, исправил опечатки в английской версии и поправил инструкции по компиляции плагина доставки в Cloud Logging.

На это уже были issue в репозиторий плагина (https://github.com/yandex-cloud/fluent-bit-plugin-yandex/issues/4, https://github.com/yandex-cloud/fluent-bit-plugin-yandex/issues/19), сам плагин поддержали, а документацию нет.

billing-account id: dn2qhja912vo4rgvddn7
