### PR TITLE
using bucket_name instead of '<имя_бакета>'

### DIFF
--- a/en/datasphere/operations/data/connect-to-s3.md
+++ b/en/datasphere/operations/data/connect-to-s3.md
@@ -42,6 +42,6 @@ To set up an S3 connection from the notebook code:
 1. Enter the bucket name and retrieve a list of objects contained in it.
 
    ```python
-   for key in s3.list_objects(Bucket='<имя_бакета>')['Contents']:
+   for key in s3.list_objects(Bucket=bucket_name)['Contents']:
        print(key['Key'])
    ```


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
Changed Bucket='<имя_бакета>' to Bucket=bucket_name, because this variable is created in step 4 of the tutorial