### PR TITLE
Add PostgreSQL connection examples for userver framework

### DIFF
--- a/en/_includes/mdb/mpg-conn-strings.md
+++ b/en/_includes/mdb/mpg-conn-strings.md
@@ -275,7 +275,11 @@ dbconnection: postgres://<имя_пользователя>:<пароль_пол�
 
 You can get the cluster ID with a [list of clusters](../../managed-postgresql/operations/cluster-list.md#list-clusters).
 
-Start the service by running `make service-start-debug`.
+Build the service and start it with the following commands:
+```bash
+make build-debug
+./build_debug/pg_<grpc_>service_template -c configs/static_config.yaml --config_vars configs/config_vars.yaml
+```
 
 ### Java {#java}
 

--- a/en/_includes/mdb/mpg-conn-strings.md
+++ b/en/_includes/mdb/mpg-conn-strings.md
@@ -259,6 +259,24 @@ go mod init example && go get github.com/jackc/pgx/v4
 
 {% endlist %}
 
+### C++ userver {#userver}
+
+Install the userver framework following the instauction as [official site](https://userver.tech/)
+or use a [VM at Yandex Cloud Marketplace](https://yandex.cloud/en/marketplace/products/yc/userver).
+
+Create your project using the service template [with gRPC](https://github.com/userver-framework/pg_grpc_service_template)
+or using the service template [without gRPC](https://github.com/userver-framework/pg_service_template).
+
+In `configs/config_vars.yaml` of your project change the `dbconnection` variable value to:
+
+```yaml
+dbconnection: postgres://<имя_пользователя>:<пароль_пользователя>@c-<идентификатор_кластера>.rw.{{ dns-zone }}:6432/<имя_БД>"
+```
+
+You can get the cluster ID with a [list of clusters](../../managed-postgresql/operations/cluster-list.md#list-clusters).
+
+Start the service by running `make service-start-debug`.
+
 ### Java {#java}
 
 Before connecting:

--- a/en/_includes/mdb/mpg-conn-strings.md
+++ b/en/_includes/mdb/mpg-conn-strings.md
@@ -261,7 +261,7 @@ go mod init example && go get github.com/jackc/pgx/v4
 
 ### C++ userver {#userver}
 
-Install the userver framework following the instauction as [official site](https://userver.tech/)
+Install the userver framework following the instruction as [official site](https://userver.tech/)
 or use a [VM at Yandex Cloud Marketplace](https://yandex.cloud/en/marketplace/products/yc/userver).
 
 Create your project using the service template [with gRPC](https://github.com/userver-framework/pg_grpc_service_template)

--- a/en/_includes/mdb/mpg-conn-strings.md
+++ b/en/_includes/mdb/mpg-conn-strings.md
@@ -270,7 +270,7 @@ or using the service template [without gRPC](https://github.com/userver-framewor
 In `configs/config_vars.yaml` of your project change the `dbconnection` variable value to:
 
 ```yaml
-dbconnection: postgres://<username>:<user_password>@c-<cluster_ID>.rw.{{ dns-zone }}:6432/<DB_name>"
+dbconnection: 'postgres://<username>:<user_password>@c-<cluster_ID>.rw.{{ dns-zone }}:6432/<DB_name>'
 ```
 
 You can get the cluster ID with a [list of clusters](../../managed-postgresql/operations/cluster-list.md#list-clusters).

--- a/en/_includes/mdb/mpg-conn-strings.md
+++ b/en/_includes/mdb/mpg-conn-strings.md
@@ -270,7 +270,7 @@ or using the service template [without gRPC](https://github.com/userver-framewor
 In `configs/config_vars.yaml` of your project change the `dbconnection` variable value to:
 
 ```yaml
-dbconnection: postgres://<имя_пользователя>:<пароль_пользователя>@c-<идентификатор_кластера>.rw.{{ dns-zone }}:6432/<имя_БД>"
+dbconnection: postgres://<username>:<user_password>@c-<cluster_ID>.rw.{{ dns-zone }}:6432/<DB_name>"
 ```
 
 You can get the cluster ID with a [list of clusters](../../managed-postgresql/operations/cluster-list.md#list-clusters).

--- a/ru/_includes/mdb/mpg-conn-strings.md
+++ b/ru/_includes/mdb/mpg-conn-strings.md
@@ -259,6 +259,22 @@ go mod init example && go get github.com/jackc/pgx/v4
 
 {% endlist %}
 
+### C++ userver {#userver}
+
+Перед подключением установите userver по инструкции с [офциального сайта userver](https://userver.tech/)
+или воспользуйтесь [готовым образом с Yandex Cloud Marketplace](https://yandex.cloud/en/marketplace/products/yc/userver).
+
+Создайте свой проект на основе сервис шаблона [с gRPC](https://github.com/userver-framework/pg_grpc_service_template)
+или на основе сервиса шаблона [без gRPC](https://github.com/userver-framework/pg_service_template).
+
+В `configs/config_vars.yaml` поменйте значение переменной `dbconnection` на
+
+```yaml
+dbconnection: postgres://<имя_пользователя>:<пароль_пользователя>@c-<идентификатор_кластера>.rw.{{ dns-zone }}:6432/<имя_БД>"
+```
+
+Идентификатор кластера можно получить со [списком кластеров](../../managed-postgresql/operations/cluster-list.md#list-clusters).
+
 ### Java {#java}
 
 Перед подключением:

--- a/ru/_includes/mdb/mpg-conn-strings.md
+++ b/ru/_includes/mdb/mpg-conn-strings.md
@@ -275,6 +275,12 @@ dbconnection: postgres://<имя_пользователя>:<пароль_пол�
 
 Идентификатор кластера можно получить со [списком кластеров](../../managed-postgresql/operations/cluster-list.md#list-clusters).
 
+Соберите и запустите сервис, используя следующие команды:
+```bash
+make build-debug
+./build_debug/pg_<grpc_>service_template -c configs/static_config.yaml --config_vars configs/config_vars.yaml
+```
+
 ### Java {#java}
 
 Перед подключением:

--- a/ru/_includes/mdb/mpg-conn-strings.md
+++ b/ru/_includes/mdb/mpg-conn-strings.md
@@ -270,7 +270,7 @@ go mod init example && go get github.com/jackc/pgx/v4
 В `configs/config_vars.yaml` поменйте значение переменной `dbconnection` на
 
 ```yaml
-dbconnection: postgres://<имя_пользователя>:<пароль_пользователя>@c-<идентификатор_кластера>.rw.{{ dns-zone }}:6432/<имя_БД>"
+dbconnection: 'postgres://<имя_пользователя>:<пароль_пользователя>@c-<идентификатор_кластера>.rw.{{ dns-zone }}:6432/<имя_БД>'
 ```
 
 Идентификатор кластера можно получить со [списком кластеров](../../managed-postgresql/operations/cluster-list.md#list-clusters).


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes: add information on how to connect to PostgreSQL if userver framework is used
