### PR TITLE
Fix typo in set endpoint_url command

### DIFF
--- a/ru/storage/quickstart/quickstart-aws-cli.md
+++ b/ru/storage/quickstart/quickstart-aws-cli.md
@@ -147,7 +147,7 @@ description: "Следуя данной инструкции, вы сможет�
       1. Задайте эндпоинт {{ objstorage-name }}:
 
           ```bash
-          aws configure set endpoint-url https://{{ s3-storage-host }}/
+          aws configure set endpoint_url https://{{ s3-storage-host }}/
           ```
 
           {% cut "Пример получившихся конфигурационных файлов" %}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:

The command should look like `aws configure set endpoint_url`, due to configuration parameter is `endpoint_url`. The next configuration file example shows correct parameter.