### PR TITLE
Fixed handling of response status code in SmartCaptcha examples

### DIFF
--- a/en/smartcaptcha/quickstart.md
+++ b/en/smartcaptcha/quickstart.md
@@ -129,7 +129,7 @@ Example of the token validation function:
            res.on('data', (content) => {
                if (res.statusCode !== 200) {
                    console.error(`Allow access due to an error: code=${res.statusCode}; message=${content}`);
-                   callback(true);
+                   callback(false);
                    return;
                }
                callback(JSON.parse(content).status === 'ok');
@@ -137,7 +137,7 @@ Example of the token validation function:
        });
        req.on('error', (error) => {
            console.error(error);
-           callback(true);
+           callback(false);
        });
        req.end();
    }
@@ -176,7 +176,7 @@ Example of the token validation function:
 
        if ($httpcode !== 200) {
            echo "Allow access due to an error: code=$httpcode; message=$server_output\n";
-           return true;
+           return false;
        }
        $resp = json_decode($server_output);
        return $resp->status === "ok";
@@ -215,7 +215,7 @@ Example of the token validation function:
        server_output = resp.content.decode()
        if resp.status_code != 200:
            print(f"Allow access due to an error: code={resp.status_code}; message={server_output}", file=sys.stderr)
-           return True
+           return False
        return json.loads(server_output)["status"] == "ok"
    token = "<token>" # For example, request.form["smart-token"]
    if check_captcha(token):

--- a/ru/smartcaptcha/quickstart.md
+++ b/ru/smartcaptcha/quickstart.md
@@ -139,7 +139,7 @@ description: "Следуя данной инструкции, вы сможет�
             res.on('data', (content) => {
                 if (res.statusCode !== 200) {
                     console.error(`Allow access due to an error: code=${res.statusCode}; message=${content}`);
-                    callback(true);
+                    callback(false);
                     return;
                 }
                 callback(JSON.parse(content).status === 'ok');
@@ -147,7 +147,7 @@ description: "Следуя данной инструкции, вы сможет�
         });
         req.on('error', (error) => {
             console.error(error);
-            callback(true);
+            callback(false);
         });
         req.end();
     }
@@ -186,7 +186,7 @@ description: "Следуя данной инструкции, вы сможет�
 
         if ($httpcode !== 200) {
             echo "Allow access due to an error: code=$httpcode; message=$server_output\n";
-            return true;
+            return false;
         }
         $resp = json_decode($server_output);
         return $resp->status === "ok";
@@ -225,7 +225,7 @@ description: "Следуя данной инструкции, вы сможет�
         server_output = resp.content.decode()
         if resp.status_code != 200:
             print(f"Allow access due to an error: code={resp.status_code}; message={server_output}", file=sys.stderr)
-            return True
+            return False
         return json.loads(server_output)["status"] == "ok"
     token = "<токен>"  # Например, request.form["smart-token"]
     if check_captcha(token):


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
in the event of any errors during an HTTP request, or if a response status other than 200 is received, it is better to return `false` to ensure that the captcha is not bypassed.