### PR TITLE
Remove duplicated entry

### DIFF
--- a/ru/iam/api-ref/grpc/index.md
+++ b/ru/iam/api-ref/grpc/index.md
@@ -18,7 +18,6 @@ Service | Description
 [YandexPassportUserAccountService](./yandex_passport_user_account_service.md) | A set of methods for managing YandexPassportUserAccount resources.
 [AccessKeyService](./access_key_service.md) | A set of methods for managing access keys.
 [CertificateService](./certificate_service.md) | A set of methods for managing certificates.
-[FederationService](./federation_service.md) | A set of methods for managing federations.
 [FederatedCredentialService](./federated_credential_service.md) | A set of methods for managing federated credentials.
 [FederationService](./federation_service.md) | A set of methods for managing OIDC workload identity federations.
 [OperationService](./operation_service.md) | A set of methods for managing operations for asynchronous API requests.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes: there are two reference to FederationService in IAM gRPC API, this patch deletes one of them.
