### PR TITLE
Update prometheus-grafana-monitoring.md

### DIFF
--- a/ru/managed-kubernetes/tutorials/prometheus-grafana-monitoring.md
+++ b/ru/managed-kubernetes/tutorials/prometheus-grafana-monitoring.md
@@ -110,6 +110,7 @@
      persistent:
        type: "persistentVolume"
        enabled: false
+       volName: "volume"
        mountPath: "/tmp/trickster"
        accessModes:
          - ReadWriteOnce
@@ -119,6 +120,7 @@
      generic:
        type: "generic"
        enabled: true
+       volName: "trickster-generic"
        mountPath: "/tmp/trickster"
    podAnnotations: {}
    resources: {}


### PR DESCRIPTION
Add "volName" , if you will try up manifest with PVC you get errors like this "Error: UPGRADE FAILED: Unable to continue with update: could not get information about the resource PersistentVolumeClaim "trickster-%!s(<nil>)-claim" in namespace "monitoring": invalid resource name "trickster-%!s(<nil>)-claim": [may not contain '%']"

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
