### PR TITLE
Update authentication.md

### DIFF
--- a/ru/container-registry/operations/authentication.md
+++ b/ru/container-registry/operations/authentication.md
@@ -41,7 +41,7 @@ description: "Перед началом работы с {{ container-registry-na
   1. Выполните команду:
 
      ```bash
-     echo <OAuth-токен> | docker login \
+     echo <OAuth-токен>|docker login \
        --username oauth \
        --password-stdin \
       {{ registry }}
@@ -65,7 +65,7 @@ description: "Перед началом работы с {{ container-registry-na
   1. Выполните команду:
 
       ```bash
-      echo <IAM-токен> | docker login \
+      echo <IAM-токен>|docker login \
         --username iam \
         --password-stdin \
         {{ registry }}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: [https://yandex.ru/legal/cla/?lang=en](https://yandex.ru/legal/cla/?lang=en)

Description of changes:

The blank spaces around the `|` symbol are incorrectly interpreted on Windows and result in an error when running the command:

`Error response from daemon: Get "https://cr.yandex/v2/": unauthorized: Password is invalid - must be OAuth token. Read more: https://cloud.yandex.ru/docs/container-registry/operations/authentication#oauth`

Removing the spaces will ensure the command will run successfully on macOS **and** Windows.