### PR TITLE
DOCS: Update create-static-conf.md

### DIFF
--- a/ru/managed-kubernetes/operations/connect/create-static-conf.md
+++ b/ru/managed-kubernetes/operations/connect/create-static-conf.md
@@ -279,6 +279,7 @@
      ```bash
      kubectl config set-cluster sa-test2 \
        --certificate-authority=ca.pem \
+       --embed-certs \
        --server=$MASTER_ENDPOINT \
        --kubeconfig=test.kubeconfig
      ```
@@ -290,6 +291,7 @@
      ```bash
      kubectl config set-cluster sa-test2 `
        --certificate-authority=ca.pem `
+       --embed-certs
        --server=$MASTER_ENDPOINT `
        --kubeconfig=test.kubeconfig
      ```

--- a/ru/managed-kubernetes/operations/connect/create-static-conf.md
+++ b/ru/managed-kubernetes/operations/connect/create-static-conf.md
@@ -291,7 +291,7 @@
      ```bash
      kubectl config set-cluster sa-test2 `
        --certificate-authority=ca.pem `
-       --embed-certs
+       --embed-certs `
        --server=$MASTER_ENDPOINT `
        --kubeconfig=test.kubeconfig
      ```


### PR DESCRIPTION
В статических файлах конфигурации практичней использовать certificate-authority-data вместо certificate-authority

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru