### PR TITLE
Terraform state typo

### DIFF
--- a/en/_tutorials/infrastructure/terraform-state-lock.md
+++ b/en/_tutorials/infrastructure/terraform-state-lock.md
@@ -150,7 +150,7 @@ To save the {{ TF }} state in {{ objstorage-name }} and activate state locking:
        endpoints = {
          s3       = "https://{{ s3-storage-host }}"
          dynamodb = "<Document_API_DB_endpoint>"
-
+       }
        bucket            = "<bucket_name>"
        region            = "{{ region-id }}"
        key               = "<path_to_state_file_in_bucket>/<state_file_name>.tfstate"
@@ -161,11 +161,11 @@ To save the {{ TF }} state in {{ objstorage-name }} and activate state locking:
        skip_credentials_validation = true
        skip_requesting_account_id  = true # This option is required for {{ TF }} 1.6.1 or higher.
        skip_s3_checksum            = true # This option is required to describe backend for {{ TF }} version 1.6.3 or higher.
-       }
      }
+   }
 
-     provider "yandex" {
-        zone = "<default_availability_zone>"
+   provider "yandex" {
+     zone = "<default_availability_zone>"
    }
    ```
 

--- a/ru/_tutorials/infrastructure/terraform-state-lock.md
+++ b/ru/_tutorials/infrastructure/terraform-state-lock.md
@@ -150,7 +150,7 @@ description: При работе с {{ TF }} в облаке важно искл
        endpoints = {
          s3       = "https://{{ s3-storage-host }}"
          dynamodb = "<эндпоинт_Document_API_БД>"
-
+       }
        bucket            = "<имя_бакета>"
        region            = "{{ region-id }}"
        key               = "<путь_к_файлу_состояния_в_бакете>/<имя_файла_состояния>.tfstate"
@@ -161,11 +161,11 @@ description: При работе с {{ TF }} в облаке важно искл
        skip_credentials_validation = true
        skip_requesting_account_id  = true # Необходимая опция {{ TF }} для версии 1.6.1 и старше.
        skip_s3_checksum            = true # Необходимая опция при описании бэкенда для {{ TF }} версии 1.6.3 и старше.
-       }
      }
+   }
 
-     provider "yandex" {
-       zone = "<зона_доступности_по_умолчанию>"
+   provider "yandex" {
+     zone = "<зона_доступности_по_умолчанию>"
    }
    ```
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
Fix typo in terraform-state-lock tutorial [ru/en]