### PR TITLE
Replaced base64 generator in docs for a website without ads.

### DIFF
--- a/en/_tutorials/serverless/alice-shareable-todolist.md
+++ b/en/_tutorials/serverless/alice-shareable-todolist.md
@@ -83,8 +83,6 @@ Substitute the values from the variables:
 * `hash`: Base64-encoded random 64-byte string, e.g., `qrJagO5NVwOj0FeTmgYSwUN+XXkiQJMWifvrklF53wT55q80Xk8vmEB3kxhtpDnA1WDC893Z9Bh6QcqK********`.
 * `block`: Base64-encoded random 32-byte string, e.g., `uwk0duFgn2nYyfu2VzJe+MnWKWQrfKaiZijI********`.
 
-You can generate random values at [real-generator.com](https://www.real-generator.com/base64).
-
 Make sure the `variables.json` file contains the correct path to `secure-config.json`.
 
 ## Deploy the project {#deploy}

--- a/en/_tutorials/serverless/alice-shareable-todolist.md
+++ b/en/_tutorials/serverless/alice-shareable-todolist.md
@@ -83,7 +83,7 @@ Substitute the values from the variables:
 * `hash`: Base64-encoded random 64-byte string, e.g., `qrJagO5NVwOj0FeTmgYSwUN+XXkiQJMWifvrklF53wT55q80Xk8vmEB3kxhtpDnA1WDC893Z9Bh6QcqK********`.
 * `block`: Base64-encoded random 32-byte string, e.g., `uwk0duFgn2nYyfu2VzJe+MnWKWQrfKaiZijI********`.
 
-You can generate random values at [generate.plus](https://generate.plus/en/base64).
+You can generate random values at [real-generator.com](https://www.real-generator.com/base64).
 
 Make sure the `variables.json` file contains the correct path to `secure-config.json`.
 

--- a/ru/_tutorials/serverless/alice-shareable-todolist.md
+++ b/ru/_tutorials/serverless/alice-shareable-todolist.md
@@ -83,10 +83,8 @@ cp secure-config-template.json secure-config.json
 
 Подставьте значения переменных:
 * `oauth_secret` — пароль приложения, зарегистрированного в [Яндекс OAuth](https://oauth.yandex.ru/).
-* `hash` — случайная строка длиной 64 байта, закодированная с помощью base64, например `qrJagO5NVwOj0FeTmgYSwUN+XXkiQJMWifvrklF53wT55q80Xk8vmEB3kxhtpDnA1WDC893Z9Bh6QcqK********`.
-* `block` — случайная строка длиной 32 байта, закодированная с помощью base64, например `uwk0duFgn2nYyfu2VzJe+MnWKWQrfKaiZijI********`.
-
-Сгенерировать случайные значения можно с помощью сайта [real-generator.com](https://www.real-generator.com/base64).
+* `hash` — случайная строка длиной 64 байта, закодированная с помощью base64, например `qrJagO5NVwOj0FeTmgYSwUN+XXkiQJMWifvrklF53wT55q80Xk8vmEB3kxhtpDnA1WDC893Z9Bh6QcqK********`. Сгенерировать случайное значение можно в терминале с помощью команды `openssl rand -base64 64 | tr -d '\n'`.
+* `block` — случайная строка длиной 32 байта, закодированная с помощью base64, например `uwk0duFgn2nYyfu2VzJe+MnWKWQrfKaiZijI********`. Сгенерировать случайное значение можно в терминале с помощью команды `openssl rand -base64 32 | tr -d '\n'`.
 
 Убедитесь, что в файле `variables.json` указан правильный путь к `secure-config.json`.
 

--- a/ru/_tutorials/serverless/alice-shareable-todolist.md
+++ b/ru/_tutorials/serverless/alice-shareable-todolist.md
@@ -86,7 +86,7 @@ cp secure-config-template.json secure-config.json
 * `hash` — случайная строка длиной 64 байта, закодированная с помощью base64, например `qrJagO5NVwOj0FeTmgYSwUN+XXkiQJMWifvrklF53wT55q80Xk8vmEB3kxhtpDnA1WDC893Z9Bh6QcqK********`.
 * `block` — случайная строка длиной 32 байта, закодированная с помощью base64, например `uwk0duFgn2nYyfu2VzJe+MnWKWQrfKaiZijI********`.
 
-Сгенерировать случайные значения можно с помощью сайта [generate.plus](https://generate.plus/en/base64).
+Сгенерировать случайные значения можно с помощью сайта [real-generator.com](https://www.real-generator.com/base64).
 
 Убедитесь, что в файле `variables.json` указан правильный путь к `secure-config.json`.
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Description of changes:
Replaced the links to the code generator with a less spammy and ad-filled alternative.