### PR TITLE
Fix link from HTTP_JSON to GRPC_JSON

### DIFF
--- a/ru/_tutorials/dev/loadtesting-grpc.md
+++ b/ru/_tutorials/dev/loadtesting-grpc.md
@@ -96,7 +96,7 @@
 
 ## Подготовьте файл с тестовыми данными {#test-file}
 
-1. Сформируйте тестовые данные в формате [HTTP_JSON](../../load-testing/concepts/payloads/http-json.md):
+1. Сформируйте тестовые данные в формате [GRPC_JSON](../../load-testing/concepts/payloads/grpc-json.md):
 
    ```JSON
    {"tag": "/Add", "call": "api.Adder.Add", "payload": {"x": 21, "y": 12}}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
- Кажется, сейчас ссылка в документации GRPC-обстрела ведет на формат HTTP_JSON, хотя на самом деле подразумевался GRPC_JSON.
