### PR TITLE
Update kubernetes-cluster-create.md

### DIFF
--- a/ru/managed-kubernetes/operations/kubernetes-cluster/kubernetes-cluster-create.md
+++ b/ru/managed-kubernetes/operations/kubernetes-cluster/kubernetes-cluster-create.md
@@ -87,7 +87,7 @@ description: Следуя данной инструкции, вы сможете
      * `--subnet-name` — имя [подсети](../../../vpc/concepts/network.md#subnet).
      * `--public-ip` — флаг, который указывает, если кластеру {{ managed-k8s-name }} требуется [публичный IP-адрес](../../../vpc/concepts/address.md#public-addresses).
      * `--release-channel` — [релизный канал](../../concepts/release-channels-and-updates.md#release-channels).
-     * `--version` — версия {{ k8s }}.
+     * `--version` — версия {{ k8s }}. Укажите версию, доступную для выбранного релизного канала.
      * `--cluster-ipv4-range` — диапазон [IP-адресов](../../../vpc/concepts/address.md), из которого будут выделяться IP-адреса для [подов](../../concepts/index.md#pod).
      * `--service-ipv4-range` — диапазон IP-адресов, из которого будут выделяться IP-адреса для [сервисов](../../concepts/index.md#service).
      * `--security-group-ids` — список идентификаторов [групп безопасности](../../../vpc/concepts/security-groups.md) кластера {{ managed-k8s-name }}.

--- a/ru/managed-kubernetes/operations/kubernetes-cluster/kubernetes-cluster-create.md
+++ b/ru/managed-kubernetes/operations/kubernetes-cluster/kubernetes-cluster-create.md
@@ -67,7 +67,7 @@ description: Следуя данной инструкции, вы сможете
        --subnet-name default-a \
        --public-ip \
        --release-channel regular \
-       --version 1.13 \
+       --version 1.27 \
        --cluster-ipv4-range 10.1.0.0/16 \
        --service-ipv4-range 10.2.0.0/16 \
        --security-group-ids enpe5sdn7vs5********,enpj6c5ifh75******** \


### PR DESCRIPTION
version is deprecated for cluster: version 1.13 is deprecated for this release channel, so use 1.27

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
