### PR TITLE
fix model and assistant initiation in simple-assistant.md

### DIFF
--- a/ru/_includes/foundation-models/examples/simple-assistant.md
+++ b/ru/_includes/foundation-models/examples/simple-assistant.md
@@ -16,8 +16,7 @@ def main() -> None:
     # Определяем модель YandexGPT Pro RC и ее максимальный контекст
     model = sdk.models.completions(
         "yandexgpt", 
-        version="rc",
-        max_tokens=500
+        model_version="rc"
     )
 
     # Создаем ассистента для модели
@@ -26,6 +25,7 @@ def main() -> None:
         model,
         ttl_days=4,
         expiration_policy="since_last_active",
+        max_tokens=500
     )
 
     # Здесь нужно предусмотреть чтение сообщений пользователей


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

"version" -> "model_version", pass "max_tokens" on assistant create. 
No "version" and "max_tokens" args in BaseCompletions