### PR TITLE
 Add command to setup metadata before connecting via serial console 

### DIFF
--- a/en/compute/operations/serial-console/connect-ssh.md
+++ b/en/compute/operations/serial-console/connect-ssh.md
@@ -55,6 +55,14 @@ Some OS's may request user credentials to access a VM. In such cases, you need t
       1. {% include [create-serial-console-user](../../../_includes/compute/create-serial-console-user.md) %}
       1. Disconnect from the VM. To do this, enter the `logout` command.
 
+  1. Enable SSH authorization for the VM when connecting to the serial console by specifying the VM name:
+
+      ```bash
+      yc compute instance update \
+      --name <VM_name> \
+      --serial-port-settings ssh-authorization=instance_metadata
+      ```
+
   1. Connect to the VM.
 
       Connection command example:

--- a/ru/compute/operations/serial-console/connect-ssh.md
+++ b/ru/compute/operations/serial-console/connect-ssh.md
@@ -55,6 +55,14 @@
       1. {% include [create-serial-console-user](../../../_includes/compute/create-serial-console-user.md) %}
       1. Отключитесь от ВМ. Для этого введите команду `logout`.
 
+  1. Включите для ВМ авторизацию по SSH при подключении к серийной консоли, указав имя ВМ:
+
+      ```bash
+      yc compute instance update \
+      --name <имя_ВМ> \
+      --serial-port-settings ssh-authorization=instance_metadata
+      ```
+
   1. Подключитесь к ВМ.
 
       Пример команды подключения:


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:

У многих образов по умолчанию включена авторизация в серийной консоли по OS Login. Эта опция включена даже если выключен доступ по OS Login. 

Если следовать строго инструкции из документации, при подключении будет возникать ошибка "Permission denied (publickey)". Чтобы это исправить, нужно включить настроить опцию "ssh-authorization=instance_metadata"