### PR TITLE
Add JavaScript example to Yandex Cloud S3 presigned-url creating

### DIFF
--- a/ru/_includes/storage/security/pre-signed-urls.md
+++ b/ru/_includes/storage/security/pre-signed-urls.md
@@ -392,5 +392,38 @@ signature = Hex(sign(SigningKey, StringToSign))
 
     print(presigned_url)
     ```
+
+- JavaScript (@aws-sdk/client-s3, @aws-sdk/s3-request-presigner) {#javascript}
+    
+    Пример генерирует подписанный URL для скачивания объекта `object-for-share` из бакета `bucket-with-objects`. URL действителен в течение 100 секунд.
+
+    ```js
+    import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+    import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+
+    const S3_ENDPOINT = "https://{{ s3-storage-host }}";
+
+    const ACCESS_KEY_ID = "JK38EXAMP********";
+    const SECRET_ACCESS_KEY = "ExamP1eSecReTKeykdo********";
+
+    const s3Client = new S3Client({
+      region: "{{ region-id }}",
+      endpoint: S3_ENDPOINT,
+      credentials: {
+        accessKeyId: ACCESS_KEY_ID,
+        secretAccessKey: SECRET_ACCESS_KEY,
+      },
+    });
+
+    const command = new PutObjectCommand({
+      Bucket: "bucket-with-objects",
+      Key: "object-for-share",
+    });
+    const objectPresignedUrl = await getSignedUrl(s3Client, command, {
+      expiresIn: 100,
+    });
+
+    console.log(objectPresignedUrl);
+    ```
           
 {% endlist %}

--- a/ru/_includes/storage/security/pre-signed-urls.md
+++ b/ru/_includes/storage/security/pre-signed-urls.md
@@ -396,66 +396,71 @@ signature = Hex(sign(SigningKey, StringToSign))
 - JavaScript {#javascript}
     
     В примерах ниже используются библиотеки [@aws-sdk/client-s3](https://www.npmjs.com/package/%40aws-sdk/client-s3) и [@aws-sdk/s3-request-presigner](https://www.npmjs.com/package/@aws-sdk/s3-request-presigner).
-    
-    Пример генерирует подписанный URL для **загрузки** объекта `object-for-share` в бакет `bucket-with-objects`. URL действителен в течение 100 секунд.
 
-    ```js
-    import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
-    import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+    * **Скачивание объекта**
 
-    const S3_ENDPOINT = "https://{{ s3-storage-host }}";
+      Пример генерирует подписанный URL для скачивания объекта `object-for-share` из бакета `bucket-with-objects`. URL действителен в течение 100 секунд.
 
-    const ACCESS_KEY_ID = "JK38EXAMP********";
-    const SECRET_ACCESS_KEY = "ExamP1eSecReTKeykdo********";
+      ```js
+      import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
+      import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 
-    const s3Client = new S3Client({
-      region: "{{ region-id }}",
-      endpoint: S3_ENDPOINT,
-      credentials: {
-        accessKeyId: ACCESS_KEY_ID,
-        secretAccessKey: SECRET_ACCESS_KEY,
-      },
-    });
+      const S3_ENDPOINT = "https://{{ s3-storage-host }}";
 
-    const command = new PutObjectCommand({
-      Bucket: "bucket-with-objects",
-      Key: "object-for-share",
-    });
-    const objectPresignedUrl = await getSignedUrl(s3Client, command, {
-      expiresIn: 100,
-    });
+      const ACCESS_KEY_ID = "JK38EXAMP********";
+      const SECRET_ACCESS_KEY = "ExamP1eSecReTKeykdo********";
 
-    console.log(objectPresignedUrl);
-    ```
+      const s3Client = new S3Client({
+        region: "{{ region-id }}",
+        endpoint: S3_ENDPOINT,
+        credentials: {
+          accessKeyId: ACCESS_KEY_ID,
+          secretAccessKey: SECRET_ACCESS_KEY,
+        },
+      });
 
-    Пример генерирует подписанный URL для **скачивания** объекта `object-for-share` из бакета `bucket-with-objects`. URL действителен в течение 100 секунд.
+      const command = new GetObjectCommand({
+        Bucket: "bucket-with-objects",
+        Key: "object-for-share",
+      });
+      const objectPresignedUrl = await getSignedUrl(s3Client, command, {
+        expiresIn: 100,
+      });
 
-    ```js
-    import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
-    import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+      console.log(objectPresignedUrl);
+      ```
 
-    const S3_ENDPOINT = "https://{{ s3-storage-host }}";
+    * **Загрузка объекта**
 
-    const ACCESS_KEY_ID = "JK38EXAMP********";
-    const SECRET_ACCESS_KEY = "ExamP1eSecReTKeykdo********";
+      Пример генерирует подписанный URL для загрузки объекта `object-for-share` в бакет `bucket-with-objects`. URL действителен в течение 100 секунд.
 
-    const s3Client = new S3Client({
-      region: "{{ region-id }}",
-      endpoint: S3_ENDPOINT,
-      credentials: {
-        accessKeyId: ACCESS_KEY_ID,
-        secretAccessKey: SECRET_ACCESS_KEY,
-      },
-    });
+      ```js
+      import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+      import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 
-    const command = new GetObjectCommand({
-      Bucket: "bucket-with-objects",
-      Key: "object-for-share",
-    });
-    const objectPresignedUrl = await getSignedUrl(s3Client, command, {
-      expiresIn: 100,
-    });
+      const S3_ENDPOINT = "https://{{ s3-storage-host }}";
 
-    console.log(objectPresignedUrl);
-    ```
+      const ACCESS_KEY_ID = "JK38EXAMP********";
+      const SECRET_ACCESS_KEY = "ExamP1eSecReTKeykdo********";
+
+      const s3Client = new S3Client({
+        region: "{{ region-id }}",
+        endpoint: S3_ENDPOINT,
+        credentials: {
+          accessKeyId: ACCESS_KEY_ID,
+          secretAccessKey: SECRET_ACCESS_KEY,
+        },
+      });
+
+      const command = new PutObjectCommand({
+        Bucket: "bucket-with-objects",
+        Key: "object-for-share",
+      });
+      const objectPresignedUrl = await getSignedUrl(s3Client, command, {
+        expiresIn: 100,
+      });
+
+      console.log(objectPresignedUrl);
+      ```
+
 {% endlist %}

--- a/ru/_includes/storage/security/pre-signed-urls.md
+++ b/ru/_includes/storage/security/pre-signed-urls.md
@@ -395,7 +395,7 @@ signature = Hex(sign(SigningKey, StringToSign))
 
 - JavaScript (@aws-sdk/client-s3, @aws-sdk/s3-request-presigner) {#javascript}
     
-    Пример генерирует подписанный URL для скачивания объекта `object-for-share` из бакета `bucket-with-objects`. URL действителен в течение 100 секунд.
+    Пример генерирует подписанный URL для загрузки объекта `object-for-share` в бакет `bucket-with-objects`. URL действителен в течение 100 секунд.
 
     ```js
     import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";

--- a/ru/_includes/storage/security/pre-signed-urls.md
+++ b/ru/_includes/storage/security/pre-signed-urls.md
@@ -425,5 +425,34 @@ signature = Hex(sign(SigningKey, StringToSign))
 
     console.log(objectPresignedUrl);
     ```
-          
+    Пример генерирует подписанный URL для скачивания объекта `object-for-share` из бакета `bucket-with-objects`. URL действителен в течение 100 секунд.
+
+    ```js
+    import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
+    import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+
+    const S3_ENDPOINT = "https://{{ s3-storage-host }}";
+
+    const ACCESS_KEY_ID = "JK38EXAMP********";
+    const SECRET_ACCESS_KEY = "ExamP1eSecReTKeykdo********";
+
+    const s3Client = new S3Client({
+      region: "{{ region-id }}",
+      endpoint: S3_ENDPOINT,
+      credentials: {
+        accessKeyId: ACCESS_KEY_ID,
+        secretAccessKey: SECRET_ACCESS_KEY,
+      },
+    });
+
+    const command = new GetObjectCommand({
+      Bucket: "bucket-with-objects",
+      Key: "object-for-share",
+    });
+    const objectPresignedUrl = await getSignedUrl(s3Client, command, {
+      expiresIn: 100,
+    });
+
+    console.log(objectPresignedUrl);
+    ```
 {% endlist %}

--- a/ru/_includes/storage/security/pre-signed-urls.md
+++ b/ru/_includes/storage/security/pre-signed-urls.md
@@ -393,7 +393,7 @@ signature = Hex(sign(SigningKey, StringToSign))
     print(presigned_url)
     ```
 
-- JavaScript (@aws-sdk/client-s3, @aws-sdk/s3-request-presigner) {#javascript}
+- JavaScript {#javascript}
     
     Пример генерирует подписанный URL для загрузки объекта `object-for-share` в бакет `bucket-with-objects`. URL действителен в течение 100 секунд.
 

--- a/ru/_includes/storage/security/pre-signed-urls.md
+++ b/ru/_includes/storage/security/pre-signed-urls.md
@@ -395,7 +395,9 @@ signature = Hex(sign(SigningKey, StringToSign))
 
 - JavaScript {#javascript}
     
-    Пример генерирует подписанный URL для загрузки объекта `object-for-share` в бакет `bucket-with-objects`. URL действителен в течение 100 секунд.
+    В примерах ниже используются библиотеки [@aws-sdk/client-s3](https://www.npmjs.com/package/%40aws-sdk/client-s3) и [@aws-sdk/s3-request-presigner](https://www.npmjs.com/package/@aws-sdk/s3-request-presigner).
+    
+    Пример генерирует подписанный URL для **загрузки** объекта `object-for-share` в бакет `bucket-with-objects`. URL действителен в течение 100 секунд.
 
     ```js
     import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
@@ -425,7 +427,8 @@ signature = Hex(sign(SigningKey, StringToSign))
 
     console.log(objectPresignedUrl);
     ```
-    Пример генерирует подписанный URL для скачивания объекта `object-for-share` из бакета `bucket-with-objects`. URL действителен в течение 100 секунд.
+
+    Пример генерирует подписанный URL для **скачивания** объекта `object-for-share` из бакета `bucket-with-objects`. URL действителен в течение 100 секунд.
 
     ```js
     import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
- Add JavaScript/Node.js example to Yandex Cloud S3 presigned-url creating (generating using aws sdk packages)

source: https://docs.aws.amazon.com/AmazonS3/latest/API/s3_example_s3_Scenario_PresignedUrl_section.html

generated page: https://server-yfm.website.yandexcloud.net/server-yfm-29e56915-23f6-46a7-bad9-18d31e4aa036/ru/storage/security/pre-signed-urls.html