### PR TITLE
Update boto3-example for boto3>=1.36.0

### DIFF
--- a/ru/_includes/storage/boto3-example.md
+++ b/ru/_includes/storage/boto3-example.md
@@ -5,7 +5,9 @@ import boto3
 session = boto3.session.Session()
 s3 = session.client(
     service_name='s3',
-    endpoint_url='https://{{ s3-storage-host }}'
+    endpoint_url='https://{{ s3-storage-host }}',
+    # Если используете boto3>=1.36.0, укажите версию сигнатуры 's3'
+    # config=boto3.session.Config(signature_version='s3'),
 )
 
 # Создать новый бакет


### PR DESCRIPTION
Starting from version 1.36.0, you must explicitly specify a compatible signature version. On version boto3<=1.35.99, this was not required.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:

Updated the `session.client`, added an indication of the config where the compatible signature version is set.