### PR TITLE
fix(tutorials): java-servlet-todo-list html header anchor typo

### DIFF
--- a/ru/_tutorials/serverless/java-servlet-todo-list.md
+++ b/ru/_tutorials/serverless/java-servlet-todo-list.md
@@ -5,7 +5,7 @@
 Чтобы создать веб-приложение:
 
 1. [Подготовьте облако к работе](#before-begin).
-1. [Подготовьте окружение](#preare).
+1. [Подготовьте окружение](#prepare).
 1. [Создайте бакет {{ objstorage-full-name }}](#create-bucket).
 1. [Создайте базу данных {{ ydb-short-name }}](#create-db).
 1. [Создайте функции {{ sf-full-name }}](#create-functions).


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
- Исправлена опечатка, из-за которой не работал якорь «2. Подготовьте окружение» на странице https://yandex.cloud/ru/docs/ydb/tutorials/java-servlet-todo-list
