### PR TITLE
Фикс опечатки и добавление инструкции для yarn

### DIFF
--- a/ru/_tutorials/serverless/nodejs-typescript.md
+++ b/ru/_tutorials/serverless/nodejs-typescript.md
@@ -1,6 +1,6 @@
 # Создание функции Node.js с помощью TypeScript
 
-Node.js не поддерживает [TypeScript](https://www.typescriptlang.org/) из коробки. Перед тем как загружать код на TypeScript в {{ sf-name }}, его необходимо скомпилировать в JavaScript.
+Node.js не поддерживает [TypeScript](https://www.typescriptlang.org/) по умолчанию. Перед тем как загружать код на TypeScript в {{ sf-name }}, его необходимо скомпилировать в JavaScript.
 
 1. Установите [Node.js](https://nodejs.org/ru/).
 1. Откройте директорию с вашим проектом.

--- a/ru/_tutorials/serverless/nodejs-typescript.md
+++ b/ru/_tutorials/serverless/nodejs-typescript.md
@@ -5,20 +5,20 @@ Node.js не поддерживает [TypeScript](https://www.typescriptlang.or
 1. Установите [Node.js](https://nodejs.org/ru/).
 1. Откройте директорию с вашим проектом.
 1. Установите [TypeScript](https://www.typescriptlang.org/download):
-   {% list tabs group=node_manager %}
-   - NPM {#npm}
-        ```bash
-        npm install typescript --save-dev
-        ```
-   - Yarn {#yarn}
-        ```bash
-        yarn add -D typescript
-        ```
-   {% endlist %}
+    {% list tabs group=node_manager %}
+    - NPM {#npm}
+         ```bash
+         npm install typescript --save-dev
+         ```
+    - Yarn {#yarn}
+         ```bash
+         yarn add -D typescript
+         ```
+    {% endlist %}
 1. Создайте конфигурацию Typescript:
-   ```bash
-       npx tsc --init --preserveConstEnums --moduleResolution Node --isolatedModules --outDir build --strict false --target ES2021
-   ```
+    ```bash
+        npx tsc --init --preserveConstEnums --moduleResolution Node --isolatedModules --outDir build --strict false --target ES2021
+    ```
 
     Чтобы использовать другую версию JavaScript, измените значение аргумента `target`. Максимальное значение версии JavaScript, которое можно указать, зависит от используемой версии Node.js:
     | Версия Node.js | Максимальная версия JavaScript |

--- a/ru/_tutorials/serverless/nodejs-typescript.md
+++ b/ru/_tutorials/serverless/nodejs-typescript.md
@@ -5,6 +5,7 @@ Node.js не поддерживает [TypeScript](https://www.typescriptlang.or
 1. Установите [Node.js](https://nodejs.org/ru/).
 1. Откройте директорию с вашим проектом.
 1. Установите [TypeScript](https://www.typescriptlang.org/download):
+   
     {% list tabs group=node_manager %}
     - NPM {#npm}
          ```bash
@@ -17,7 +18,7 @@ Node.js не поддерживает [TypeScript](https://www.typescriptlang.or
     {% endlist %}
 1. Создайте конфигурацию Typescript:
     ```bash
-        npx tsc --init --preserveConstEnums --moduleResolution Node --isolatedModules --outDir build --strict false --target ES2021
+    npx tsc --init --preserveConstEnums --moduleResolution Node --isolatedModules --outDir build --strict false --target ES2021
     ```
 
     Чтобы использовать другую версию JavaScript, измените значение аргумента `target`. Максимальное значение версии JavaScript, которое можно указать, зависит от используемой версии Node.js:

--- a/ru/_tutorials/serverless/nodejs-typescript.md
+++ b/ru/_tutorials/serverless/nodejs-typescript.md
@@ -10,7 +10,7 @@ Node.js не поддерживает [TypeScript](https://www.typescriptlang.or
     ```
 1. Создайте конфигурацию Typescript:
     ```bash
-    npx tsc --init --preserveConstEnums --moduleResolution Node --isolatedModules --outDir build --strict false --target ES2021
+    npx --no-install tsc --init --preserveConstEnums --moduleResolution Node --isolatedModules --outDir build --strict false --target ES2021
     ```
 
     Чтобы использовать другую версию JavaScript, измените значение аргумента `target`. Максимальное значение версии JavaScript, которое можно указать, зависит от используемой версии Node.js:

--- a/ru/_tutorials/serverless/nodejs-typescript.md
+++ b/ru/_tutorials/serverless/nodejs-typescript.md
@@ -1,17 +1,24 @@
 # Создание функции Node.js с помощью TypeScript
 
-Node.js не поддерживает [TypeScript](https://www.typescriptlang.org/). Перед тем как загружать код на TypeScript в {{ sf-name }}, его необходимо скомпилировать в JavaScript.
+Node.js не поддерживает [TypeScript](https://www.typescriptlang.org/) из коробки. Перед тем как загружать код на TypeScript в {{ sf-name }}, его необходимо скомпилировать в JavaScript.
 
 1. Установите [Node.js](https://nodejs.org/ru/).
 1. Откройте директорию с вашим проектом.
 1. Установите [TypeScript](https://www.typescriptlang.org/download):
-    ```bash
-    npm install typescript --save-dev
-    ```
+   {% list tabs group=node_manager %}
+   - NPM {#npm}
+        ```bash
+        npm install typescript --save-dev
+        ```
+   - Yarn {#yarn}
+        ```bash
+        yarn add -D typescript
+        ```
+   {% endlist %}
 1. Создайте конфигурацию Typescript:
-    ```bash
-    npx ts --init --preserveConstEnums --moduleResolution Node --isolatedModules --outDir build --strict false --target ES2021
-    ```
+   ```bash
+       npx tsc --init --preserveConstEnums --moduleResolution Node --isolatedModules --outDir build --strict false --target ES2021
+   ```
 
     Чтобы использовать другую версию JavaScript, измените значение аргумента `target`. Максимальное значение версии JavaScript, которое можно указать, зависит от используемой версии Node.js:
     | Версия Node.js | Максимальная версия JavaScript |

--- a/ru/_tutorials/serverless/nodejs-typescript.md
+++ b/ru/_tutorials/serverless/nodejs-typescript.md
@@ -1,6 +1,6 @@
 # Создание функции Node.js с помощью TypeScript
 
-Node.js не поддерживает [TypeScript](https://www.typescriptlang.org/) по умолчанию. Перед тем как загружать код на TypeScript в {{ sf-name }}, его необходимо скомпилировать в JavaScript.
+По умолчанию Node.js не поддерживает [TypeScript](https://www.typescriptlang.org/). Перед тем как загружать код на TypeScript в {{ sf-name }}, его необходимо скомпилировать в JavaScript.
 
 1. Установите [Node.js](https://nodejs.org/ru/).
 1. Откройте директорию с вашим проектом.

--- a/ru/_tutorials/serverless/nodejs-typescript.md
+++ b/ru/_tutorials/serverless/nodejs-typescript.md
@@ -5,17 +5,9 @@ Node.js не поддерживает [TypeScript](https://www.typescriptlang.or
 1. Установите [Node.js](https://nodejs.org/ru/).
 1. Откройте директорию с вашим проектом.
 1. Установите [TypeScript](https://www.typescriptlang.org/download):
-   
-    {% list tabs group=node_manager %}
-    - NPM {#npm}
-         ```bash
-         npm install typescript --save-dev
-         ```
-    - Yarn {#yarn}
-         ```bash
-         yarn add -D typescript
-         ```
-    {% endlist %}
+    ```bash
+    npm install typescript --save-dev
+    ```
 1. Создайте конфигурацию Typescript:
     ```bash
     npx tsc --init --preserveConstEnums --moduleResolution Node --isolatedModules --outDir build --strict false --target ES2021


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Описание изменений:
+ Исправлена опечатка (с ts на tsc):
    + ``npx ts --init`` на ``npx tsс --init``
+ Добавление варианта установки TS с помощью Yarn
+ Уточнение неточности:
    + Node.js не поддерживает [TypeScript](https://www.typescriptlang.org/) **_из коробки_**.