### PR TITLE
Normalize indentation for the vision includes

### DIFF
--- a/en/_includes/vision/base64-encode-command-pdf.md
+++ b/en/_includes/vision/base64-encode-command-pdf.md
@@ -3,74 +3,74 @@
 
 - UNIX {#unix}
 
-   ```
-   base64 -i input.pdf > output.txt
-   ```
+  ```
+  base64 -i input.pdf > output.txt
+  ```
 
 - Windows {#windows}
 
-   ```
-   C:> Base64.exe -e input.pdf > output.txt
-   ```
+  ```
+  C:> Base64.exe -e input.pdf > output.txt
+  ```
 
 - PowerShell {#powershell}
 
-   ```
-   [Convert]::ToBase64String([IO.File]::ReadAllBytes("./input.pdf")) > output.txt
-   ```
+  ```
+  [Convert]::ToBase64String([IO.File]::ReadAllBytes("./input.pdf")) > output.txt
+  ```
 
 - Python {#python}
 
-   ```python
-   # Import a library for encoding files in Base64
-   import base64
+  ```python
+  # Import a library for encoding files in Base64
+  import base64
 
-   # Create a function that will encode a file and return results.
-   def encode_file(file):
-     file_content = file.read()
-     return base64.b64encode(file_content)
-   ```
+  # Create a function that will encode a file and return results.
+  def encode_file(file):
+    file_content = file.read()
+    return base64.b64encode(file_content)
+  ```
 
 - Node.js {#node}
 
-   ```js
-   // Read the file contents to memory.
-   var fs = require('fs');
-   var file = fs.readFileSync('/path/to/file');
+  ```js
+  // Read the file contents to memory.
+  var fs = require('fs');
+  var file = fs.readFileSync('/path/to/file');
 
-   // Get the file contents in Base64 format.
-   var encoded = Buffer.from(file).toString('base64');
-   ```
+  // Get the file contents in Base64 format.
+  var encoded = Buffer.from(file).toString('base64');
+  ```
 
 - Java {#java}
 
-   ```java
-   // Import a library for encoding files in Base64.
-   import org.apache.commons.codec.binary.Base64;
+  ```java
+  // Import a library for encoding files in Base64.
+  import org.apache.commons.codec.binary.Base64;
 
-   // Get the file contents in Base64 format.
-   byte[] fileData = Base64.encodeBase64(yourFile.getBytes());
-   ```
+  // Get the file contents in Base64 format.
+  byte[] fileData = Base64.encodeBase64(yourFile.getBytes());
+  ```
 
 - Go {#go}
 
-   ```go
-   import (
-       "bufio"
-       "encoding/base64"
-       "io/ioutil"
-       "os"
-   )
+  ```go
+  import (
+    "bufio"
+    "encoding/base64"
+    "io/ioutil"
+    "os"
+  )
 
-   // Open the file
-   f, _ := os.Open("/path/to/file")
+  // Open the file
+  f, _ := os.Open("/path/to/file")
 
-   // Read the file contents.
-   reader := bufio.NewReader(f)
-   content, _ := ioutil.ReadAll(reader)
+  // Read the file contents.
+  reader := bufio.NewReader(f)
+  content, _ := ioutil.ReadAll(reader)
 
-   // Get the file contents in Base64 format.
-   base64.StdEncoding.EncodeToString(content)
-   ```
+  // Get the file contents in Base64 format.
+  base64.StdEncoding.EncodeToString(content)
+  ```
 
 {% endlist %}

--- a/en/_includes/vision/base64-encode-command.md
+++ b/en/_includes/vision/base64-encode-command.md
@@ -28,7 +28,7 @@
   # Create a function to encode a file and return the results.
   def encode_file(file_path):
     with open(file_path, "rb") as fid:
-        file_content = fid.read()
+      file_content = fid.read()
     return base64.b64encode(file_content).decode("utf-8")
   ```
 
@@ -57,10 +57,10 @@
 
   ```go
   import (
-      "bufio"
-      "encoding/base64"
-      "io/ioutil"
-      "os"
+    "bufio"
+    "encoding/base64"
+    "io/ioutil"
+    "os"
   )
 
   // Open the file.

--- a/en/_includes/vision/send-request_ocr.md
+++ b/en/_includes/vision/send-request_ocr.md
@@ -41,7 +41,7 @@ Send a request using the [recognize](../../vision/ocr/api-ref/TextRecognition/re
             "x-folder-id": "<folder_ID>",
             "x-data-logging-enabled": "true"}
     
-    w = requests.post(url=url, headers=headers, data=json.dumps(data))
+  w = requests.post(url=url, headers=headers, data=json.dumps(data))
   ```
 
 {% endlist %}

--- a/ru/_includes/vision/base64-encode-command-pdf.md
+++ b/ru/_includes/vision/base64-encode-command-pdf.md
@@ -56,10 +56,10 @@
   
   ```go
   import (
-      "bufio"
-      "encoding/base64"
-      "io/ioutil"
-      "os"
+    "bufio"
+    "encoding/base64"
+    "io/ioutil"
+    "os"
   )
   
   // Откройте файл

--- a/ru/_includes/vision/base64-encode-command.md
+++ b/ru/_includes/vision/base64-encode-command.md
@@ -28,7 +28,7 @@
   # Создайте функцию, которая кодирует файл и возвращает результат.
   def encode_file(file_path):
     with open(file_path, "rb") as fid:
-        file_content = fid.read()
+      file_content = fid.read()
     return base64.b64encode(file_content).decode("utf-8")
   ```
   
@@ -57,10 +57,10 @@
   
   ```go
   import (
-      "bufio"
-      "encoding/base64"
-      "io/ioutil"
-      "os"
+    "bufio"
+    "encoding/base64"
+    "io/ioutil"
+    "os"
   )
   
   // Откройте файл

--- a/ru/_includes/vision/send-request_ocr.md
+++ b/ru/_includes/vision/send-request_ocr.md
@@ -41,7 +41,7 @@
             "x-folder-id": "<идентификатор_каталога>",
             "x-data-logging-enabled": "true"}
     
-    w = requests.post(url=url, headers=headers, data=json.dumps(data))
+  w = requests.post(url=url, headers=headers, data=json.dumps(data))
   ```
 
 {% endlist %}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes: Normalize the indentation of the _includes/vision/ in both languages.