### PR TITLE
Updated link to OAuth token revoke

### DIFF
--- a/en/iam/operations/compromised-credentials.md
+++ b/en/iam/operations/compromised-credentials.md
@@ -32,7 +32,7 @@ You can revoke an OAuth token. In this case, the IAM tokens obtained using the O
 
 To prevent a hacker from using your token:
 
-1. [Revoke the OAuth token](https://passport.yandex.ru/profile/access). To do this you need to revoke Yandex Cloud application. ID: 1a6990aa636648e9b2ef855fa7bec2fb 
+1. [Revoke the OAuth token](https://passport.yandex.com/profile/access). To do this you need to revoke Yandex Cloud application. ID: 1a6990aa636648e9b2ef855fa7bec2fb 
 1. [Revoke](./iam-token/revoke-iam-token.md) all IAM tokens obtained using the compromised OAuth token.
 1. [Get a new OAuth token]({{ link-cloud-oauth }}).
 

--- a/en/iam/operations/compromised-credentials.md
+++ b/en/iam/operations/compromised-credentials.md
@@ -32,7 +32,7 @@ You can revoke an OAuth token. In this case, the IAM tokens obtained using the O
 
 To prevent a hacker from using your token:
 
-1. [Revoke the OAuth token](https://passport.yandex.com/profile/access). To do this you need to revoke Yandex Cloud application. ID: 1a6990aa636648e9b2ef855fa7bec2fb 
+1. [Revoke the OAuth token](https://yandex.com/dev/oauth/doc/dg/reference/token-invalidate.html).
 1. [Revoke](./iam-token/revoke-iam-token.md) all IAM tokens obtained using the compromised OAuth token.
 1. [Get a new OAuth token]({{ link-cloud-oauth }}).
 

--- a/en/iam/operations/compromised-credentials.md
+++ b/en/iam/operations/compromised-credentials.md
@@ -32,7 +32,7 @@ You can revoke an OAuth token. In this case, the IAM tokens obtained using the O
 
 To prevent a hacker from using your token:
 
-1. [Revoke the OAuth token](https://yandex.com/dev/oauth/doc/dg/reference/token-invalidate.html).
+1. [Revoke the OAuth token](https://passport.yandex.ru/profile/access). To do this you need to revoke Yandex Cloud application. ID: 1a6990aa636648e9b2ef855fa7bec2fb 
 1. [Revoke](./iam-token/revoke-iam-token.md) all IAM tokens obtained using the compromised OAuth token.
 1. [Get a new OAuth token]({{ link-cloud-oauth }}).
 

--- a/ru/iam/operations/compromised-credentials.md
+++ b/ru/iam/operations/compromised-credentials.md
@@ -32,7 +32,7 @@ OAuth-токен можно отозвать. При этом IAM-токены, 
 
 Чтобы злоумышленник не смог использовать токен:
 
-1. [Отзовите OAuth-токен](https://yandex.ru/dev/id/doc/dg/oauth/reference/token-invalidate.html).
+1. [Отзовите OAuth-токен](https://passport.yandex.ru/profile/access). Для этого нужно отозвать приложение Яндекс Облако (Yandex Cloud). ID: 1a6990aa636648e9b2ef855fa7bec2fb
 1. [Отзовите](./iam-token/revoke-iam-token.md) все IAM-токены, для получения которых использовался скомпрометированный OAuth-токен.
 1. [Получите новый OAuth-токен]({{ link-cloud-oauth }}).
 

--- a/ru/iam/operations/compromised-credentials.md
+++ b/ru/iam/operations/compromised-credentials.md
@@ -32,7 +32,7 @@ OAuth-токен можно отозвать. При этом IAM-токены, 
 
 Чтобы злоумышленник не смог использовать токен:
 
-1. [Отзовите OAuth-токен](https://passport.yandex.ru/profile/access). Для этого нужно отозвать приложение Яндекс Облако (Yandex Cloud). ID: 1a6990aa636648e9b2ef855fa7bec2fb
+1. [Отзовите](https://passport.yandex.ru/profile/access) OAuth-токен. Для этого нужно отозвать доступ приложения {{ yandex-cloud }}. Подробнее см. [Отзыв токенов](https://yandex.ru/dev/id/doc/dg/oauth/reference/token-invalidate.html).
 1. [Отзовите](./iam-token/revoke-iam-token.md) все IAM-токены, для получения которых использовался скомпрометированный OAuth-токен.
 1. [Получите новый OAuth-токен]({{ link-cloud-oauth }}).
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:

Updated link to yandex passport, where OAuth token can be revoked
