### PR TITLE
Update parquet compression links in documentation

### DIFF
--- a/ru/query/sources-and-sinks/formats.md
+++ b/ru/query/sources-and-sinks/formats.md
@@ -309,8 +309,8 @@ WITH(
 
 |Формат сжатия|Название в {{ yq-name }}|
 |--|--|
-|[Raw](https://ru.wikipedia.org/wiki/Gzip)|raw|
-|[Snappy](https://ru.wikipedia.org/wiki/Gzip)|snappy|
+|[Raw](https://github.com/apache/parquet-format/blob/master/Compression.md)|raw|
+|[Snappy](https://en.wikipedia.org/wiki/Snappy_(compression))|snappy|
 
 ### Запись в {{ objstorage-full-name }} {#write_objstorage}
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
Replaced incorrect Wikipedia links about the `Raw` and `Snappy` compression formats in the `Parquet` section of the documentation.
The previous links pointed to `Gzip` compression, which was inaccurate.
Now the links direct to the official Apache Parquet compression documentation and the correct Wikipedia page for Snappy.