### PR TITLE
Fix incorrect type for security_group_id in SG rule example referencing another SG

### DIFF
--- a/ru/vpc/concepts/security-groups.md
+++ b/ru/vpc/concepts/security-groups.md
@@ -174,7 +174,7 @@ resource "yandex_vpc_security_group" "db_sg" {
     description       = "Permit DB access to Web VM's"
     protocol          = "TCP"
     port              = 6432
-    security_group_id = [ yandex_vpc_security_group.web_sg.id ]
+    security_group_id = yandex_vpc_security_group.web_sg.id
   }
 }
 ```


### PR DESCRIPTION
Replaced incorrect usage of `security_group_id = [ ... ]` with the correct form `security_group_id = ...`, since the attribute expects a string, not a list.

https://terraform-provider.yandexcloud.net/resources/vpc_security_group

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
