### PR TITLE
Update nginx-ingress-certificate-manager.md

### DIFF
--- a/ru/_tutorials/containers/nginx-ingress-certificate-manager.md
+++ b/ru/_tutorials/containers/nginx-ingress-certificate-manager.md
@@ -136,12 +136,19 @@
      --from-file=authorized-key=authorized-key.json
    ```
 
-1. Создайте [хранилище секретов (SecretStore)](https://external-secrets.io/v0.5.8/api-secretstore/) `secret-store`, содержащее секрет `yc-auth`:
+1. Узнайте поддерживаемые `apiVersion` для [хранилища секретов (SecretStore)](https://external-secrets.io/v0.5.8/api-secretstore/):
+
+   ```bash
+   kubectl get crd secretstores.external-secrets.io \
+     -o json | jq -r '.spec.versions[].name'
+   ```
+
+1. Создайте хранилище секретов с именем `secret-store`, содержащее секрет `yc-auth`, указав поддерживаемую `apiVersion`:
 
 
    ```bash
    kubectl --namespace ns apply -f - <<< '
-   apiVersion: external-secrets.io/v1
+   apiVersion: external-secrets.io/v1beta1
    kind: SecretStore
    metadata:
      name: secret-store
@@ -158,11 +165,18 @@
 
 ## Создайте ExternalSecret {#create-externalsecret}
 
-1. Создайте объект [ExternalSecret](https://external-secrets.io/v0.5.8/api-externalsecret/) `external-secret`, указывающий на сертификат из {{ certificate-manager-name }}:
+1. Узнайте поддерживаемые `apiVersion` для [ExternalSecret](https://external-secrets.io/v0.5.8/api-externalsecret/):
+
+   ```bash
+   kubectl get crd externalsecrets.external-secrets.io \
+     -o json | jq -r '.spec.versions[].name'
+   ```
+
+1. Создайте объект ExternalSecret с именем `external-secret`, указывающий на сертификат из {{ certificate-manager-name }}, указав поддерживаемую `apiVersion`:
 
    ```bash
    kubectl --namespace ns apply -f - <<< '
-   apiVersion: external-secrets.io/v1
+   apiVersion: external-secrets.io/v1beta1
    kind: ExternalSecret
    metadata:
      name: external-secret


### PR DESCRIPTION
Обновлена версия API ресурса `SecretStore` с `external-secrets.io/v1beta1` на актуальную `external-secrets.io/v1`.

Причина: при установке External Secrets Operator через Helm (`external-secrets/external-secrets`) создаются CRD только с `v1`. Попытка применить манифест с `v1beta1` вызывает ошибку: no matches for kind "SecretStore" in version "external-secrets.io/v1beta1"

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
