### PR TITLE
Update gitlab-containers.md

### DIFF
--- a/ru/_tutorials/dev/gitlab-containers.md
+++ b/ru/_tutorials/dev/gitlab-containers.md
@@ -263,7 +263,9 @@
               - docker push "${CI_REGISTRY}/${CI_PROJECT_PATH}:${CI_COMMIT_SHORT_SHA}"
 
           deploy:
-            image: bitnami/kubectl:latest
+            image:
+              name: bitnami/kubectl:latest
+              entrypoint: [""]
             stage: deploy
             script:
               - kubectl config use-context ${CI_PROJECT_PATH}:<имя_GitLab_Agent>


### PR DESCRIPTION
ошибка в сборке контейнера с помощью docker:dind

без указания как в изменении падает с ошибкой

```
error: unknown command "sh" for "kubectl"
Did you mean this?
	set
	cp
```

Для сборки контейнера с помощью kaniko указано верно

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
