### PR TITLE
Update prometheus-grafana-monitoring.md

### DIFF
--- a/ru/_tutorials/k8s/prometheus-grafana-monitoring.md
+++ b/ru/_tutorials/k8s/prometheus-grafana-monitoring.md
@@ -367,4 +367,4 @@
 Удалите ресурсы, которые вы больше не будете использовать, чтобы за них не списывалась плата:
 1. [Удалите кластер {{ managed-k8s-name }}](../../managed-kubernetes/operations/kubernetes-cluster/kubernetes-cluster-delete.md).
 1. Если вы зарезервировали для кластера {{ managed-k8s-name }} [публичный статический IP-адрес](../../vpc/concepts/address.md#public-addresses), [удалите его](../../vpc/operations/address-delete.md).
-1. [Удалите диск](https://yandex.cloud/ru/docs/compute/operations/disk-control/delete), который был создан для хранилища `trickster`, определить его можно по метке в описании диска, метку можно узнать через `kubectl describe pvc trickster-pvc` она будет соответсвовать значению в поле `Volume:`
+1. [Удалите диск](../../compute/operations/disk-control/delete.md), который был создан для хранилища `trickster`. Определить его можно по метке в описании диска, метку можно узнать с помощью команды `kubectl describe pvc trickster-pvc` — она будет соответствовать значению в поле `Volume`.


### PR DESCRIPTION
Текущая инструкция не работает
Helm репозиторий trickster перенесен в отдельный проект на гитхабе https://github.com/trickstercache/helm-charts/ 

Но версия 1.1 недоступна для скачивания через чарт

Конфиг, который я предлагаю работает, трикстер получает информацию от промитиуса и доступен на http://trickster:8480 из подов

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
