### PR TITLE
fix YC CLI errors with creating/moving subnets

### DIFF
--- a/ru/_tutorials/routing/multi-folder-vpc.md
+++ b/ru/_tutorials/routing/multi-folder-vpc.md
@@ -267,10 +267,10 @@
         yc vpc subnet create --folder-name net-folder --name subnet-a \
           --network-name shared-net --zone {{ region-id }}-a --range 10.1.11.0/24
 
-        yc vpc subnet create --folder-name dev-folder --name subnet-b \
+        yc vpc subnet create --folder-name net-folder --name subnet-b \
           --network-name shared-net --zone {{ region-id }}-b --range 10.1.12.0/24
 
-        yc vpc subnet create --folder-name prod-folder --name subnet-d \
+        yc vpc subnet create --folder-name net-folder --name subnet-d \
           --network-name shared-net --zone {{ region-id }}-d --range 10.1.13.0/24
         ```
 
@@ -358,6 +358,7 @@
 
      ```bash
      yc vpc subnet move subnet-b \
+       --folder-name net-folder \
        --destination-folder-name dev-folder
      ```
 


### PR DESCRIPTION
From this snippet
```sh
yc vpc subnet create --folder-name net-folder --name subnet-a \
  --network-name shared-net --zone ru-central1-a --range 10.1.11.0/24

yc vpc subnet create --folder-name dev-folder --name subnet-b \
  --network-name shared-net --zone ru-central1-b --range 10.1.12.0/24

yc vpc subnet create --folder-name prod-folder --name subnet-d \
  --network-name shared-net --zone ru-central1-d --range 10.1.13.0/24
```
only first command will succseed because there is no network named `shared-net` in folders `dev-folder` or `prod-folder`

Correct order of actions:
1. create all subnets in `net-folder`
2. move specific subnets to desired folders

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
