### PR TITLE
Update nginx-ingress-certificate-manager.md

### DIFF
--- a/ru/_tutorials/containers/nginx-ingress-certificate-manager.md
+++ b/ru/_tutorials/containers/nginx-ingress-certificate-manager.md
@@ -149,7 +149,7 @@
    ```bash
    kubectl --namespace ns apply -f - <<< '
    apiVersion: external-secrets.io/v1beta1
-   kind: ClusterSecretStore
+   kind: SecretStore
    metadata:
      name: yc-cert-manager
    spec:
@@ -162,7 +162,11 @@
              namespace: ns'
    ```
 
+   {% note tip %}
 
+   В примере хранилище секретов создается с типом `kind: SecretStore`, оно будет доступно только в пространстве имен `ns`, в котором было создано. Чтобы хранилище секретов было доступно во всех пространствах имен, используйте тип `kind: ClusterSecretStore`.
+
+   {% endnote %}
 
 ## Создайте ExternalSecret {#create-externalsecret}
 
@@ -185,7 +189,7 @@
      refreshInterval: 1h
      secretStoreRef:
        name: yc-cert-manager
-       kind: ClusterSecretStore
+       kind: SecretStore
      target:
        name: k8s-secret
        template:
@@ -200,6 +204,12 @@
          key: <идентификатор_сертификата>
          property: privateKey'
    ```
+
+   {% note info %}
+
+   Если вы создавали хранилище секретов с типом `kind: ClusterSecretStore`, исправьте в примере манифеста значение `spec:secretStoreRef:kind` на `ClusterSecretStore`.
+
+   {% endnote %}
 
    Где:
    * `k8s-secret` — имя секрета, в который External Secret Operator поместит сертификат из {{ certificate-manager-name }}.


### PR DESCRIPTION
Changed name of secret-store.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:

Изменено название SecretStore для использования серкрета для доступа к yandex cert manager на yc-cert-manager. 
Изменен тип хранилища с SecretStore на ClusterSecretStore для возможности использования yc-cert-manager из любого неймспейса. 
Исправлена ошибка в .spec.provider.yandexcertificatemanager.auth.authorizedKeySecretRef.key. В примере в секрете yc-auth значение хранится в поле authorized-key.json

