### PR TITLE
Docs: remove header requirement for /latest/ 

### DIFF
--- a/ru/_includes/compute/metadata/internal-request-examples.md
+++ b/ru/_includes/compute/metadata/internal-request-examples.md
@@ -35,7 +35,6 @@ curl \
 
 ```bash
 curl \
-  --header Metadata-Flavor:Google \
   169.254.169.254/latest/user-data
 ```
 
@@ -61,7 +60,6 @@ users:
 curl \
   --silent \
   --fail \
-  --header Metadata-Flavor:Google \
   169.254.169.254/latest/user-data | \
   yq .users[].name
 ```


### PR DESCRIPTION
The documentation previously stated that all requests to the /latest/ endpoint require the Metadata-Flavor:Google header.
However, in practice the service still accepts requests without this header.

This PR updates the examples to reflect the actual behavior by removing the header requirement from /latest/ requests.

Note: I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru