### PR TITLE
Update kubernetes-lockbox-secrets.md

### DIFF
--- a/ru/_tutorials/containers/kubernetes-lockbox-secrets.md
+++ b/ru/_tutorials/containers/kubernetes-lockbox-secrets.md
@@ -181,7 +181,7 @@
    ```bash
    kubectl --namespace ns get secret k8s-secret \
      --output=json | \
-     jq --raw-output ."data"."password" | \
+     jq --raw-output '."data"."password"' | \
      base64 --decode
    ```
 


### PR DESCRIPTION
Без одинарных кавычек ловим ошибку, пример:
```bash
  jq --raw-output ."data"."gdocs-gi-project" | \
  base64 --decode
jq: error: gi/0 is not defined at <top-level>, line 1:
.data.gdocs-gi-project            
jq: error: project/0 is not defined at <top-level>, line 1:
.data.gdocs-gi-project               
jq: 2 compile errors
```

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
