### PR TITLE
Fix ydb cli install URL

### DIFF
--- a/en/ydb/quickstart.md
+++ b/en/ydb/quickstart.md
@@ -261,7 +261,7 @@ For the Amazon DynamoDB-compatible mode, use a serverless database configuration
 
   1. {% include [cli-install](../_includes/cli-install.md) %}
 
-  1. To manage your DBs from the command line, [install](https://{{ ydb.docs }}/reference/ydb-cli/install) the {{ ydb-short-name }} CLI.
+  1. To manage your DBs from the command line, [install]({{ ydb.docs }}/reference/ydb-cli/install) the {{ ydb-short-name }} CLI.
   1. To authenticate the {{ ydb-short-name }} CLI in {{ yandex-cloud }}, get an [IAM token](../iam/concepts/authorization/iam-token.md) and export it to the following environment variable:
 
      ```bash

--- a/ru/ydb/quickstart.md
+++ b/ru/ydb/quickstart.md
@@ -261,7 +261,7 @@ description: Следуя данной инструкции, вы сможете
 
   1. {% include [cli-install](../_includes/cli-install.md) %}
 
-  1. Чтобы управлять вашими БД из командной строки, [установите](https://{{ ydb.docs }}/reference/ydb-cli/install) {{ ydb-short-name }} CLI.
+  1. Чтобы управлять вашими БД из командной строки, [установите]({{ ydb.docs }}/reference/ydb-cli/install) {{ ydb-short-name }} CLI.
   1. Для аутентификации {{ ydb-short-name }} CLI в {{ yandex-cloud }} получите [IAM-токен](../iam/concepts/authorization/iam-token.md) и экспортируйте его в переменную окружения:
 
      ```bash


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
Без этих изменений ссылка выглядит, как `https://https://ydb.tech/docs/en//reference/ydb-cli/install` и не работает.