### PR TITLE
Update create-with-cloud-init-scripts.md

### DIFF
--- a/ru/compute/operations/vm-create/create-with-cloud-init-scripts.md
+++ b/ru/compute/operations/vm-create/create-with-cloud-init-scripts.md
@@ -235,7 +235,8 @@ description: Следуя данной инструкции, вы сможете
     - <публичный_SSH-ключ>
   write_files:
     - path: "/usr/local/etc/yc-install.sh"
-      permissions: "755"
+      permissions: "0755"
+      owner: <имя_пользователя>:<имя_пользователя>
       content: |
         #!/bin/bash
 
@@ -251,6 +252,9 @@ description: Следуя данной инструкции, вы сможете
         # Save YC params
         echo "Saving YC params to the ~/.bashrc"
         cat << EOF >> $HOME/.bashrc
+          export PATH="$HOME/yandex-cloud/bin:$PATH"
+          export YC_CLI_VM_ID="${VM_ID:-unknown}"
+        EOF
       defer: true
   runcmd:
     - [su, <имя_пользователя>, -c, "/usr/local/etc/yc-install.sh"]


### PR DESCRIPTION
при установке yc cli ошибка - ус не был добавлен в path также лучше указать 
owner: yc-user:yc-user
рекомендуют права писать в сведущим нулем 
permissions: "0755"

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
