### PR TITLE
Update ingress-cert-manager.md

### DIFF
--- a/ru/_tutorials/k8s/ingress-cert-manager.md
+++ b/ru/_tutorials/k8s/ingress-cert-manager.md
@@ -117,7 +117,7 @@
 
 - Вручную {#manual}
 
-  1. Установите [актуальную версию](https://github.com/cert-manager/cert-manager/releases) cert-manager. Например, для версии 1.21.1 выполните команду:
+  1. Установите [актуальную версию](https://github.com/cert-manager/cert-manager/releases) cert-manager. Например, для версии 1.12.1 выполните команду:
 
      ```bash
      kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.12.1/cert-manager.yaml


### PR DESCRIPTION
Опечатка

"Например, для версии 1.21.1 выполните команду:"

"download/v1.12.1"

версию устанавливаем 1.12.1

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
