### PR TITLE
Fix security group in wordpress: allow connection on 22 port (for a ssh connection)

### DIFF
--- a/ru/_tutorials/_tutorials_includes/wordpress/setup-console.md
+++ b/ru/_tutorials/_tutorials_includes/wordpress/setup-console.md
@@ -37,6 +37,7 @@
      Исходящий | any | Весь | Любой | CIDR | 0.0.0.0/0
      Входящий | ext-http | 80 | TCP | CIDR | 0.0.0.0/0
      Входящий | ext-https | 443 | TCP | CIDR | 0.0.0.0/0
+     Входящий | ext-ssh | 22 | TCP | CIDR | 0.0.0.0/0
 
      1. Выберите вкладку **{{ ui-key.yacloud.vpc.network.security-groups.label_egress }}** или **{{ ui-key.yacloud.vpc.network.security-groups.label_ingress }}**.
      1. Нажмите кнопку **{{ ui-key.yacloud.vpc.network.security-groups.button_add-rule }}**.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
В инструкции выполняется подключение к машине для получения логина/пароля к WordPress, но невозможно, если не разрешить подключение TCP по 22 порту в группе безопасности.