### PR TITLE
добавлена ссылка на библиотеку ЯндексMQ для 1С:Предприятия 8

### DIFF
--- a/en/message-queue/instruments/index.md
+++ b/en/message-queue/instruments/index.md
@@ -2,6 +2,10 @@
 
 To access the API, use any Amazon SQS compatible tools, such as AWS CLI, Boto3, or other [supported by SDK](https://aws.amazon.com/tools/#sdk).
 
+
+## Other SDK {#sdk}
+* [Client library for 1C:Enterprise 8](https://github.com/leemuar/yandexmq-sdk-1c)
+
 ## Getting started {#preparations}
 
 1. [Create a service account](../../iam/operations/sa/create.md).

--- a/ru/message-queue/instruments/index.md
+++ b/ru/message-queue/instruments/index.md
@@ -3,7 +3,7 @@
 Для использования [API](../../glossary/rest-api.md) подходят все инструменты, совместимые с Amazon SQS: AWS CLI, Boto3 и другие [поддерживаемые SDK](https://aws.amazon.com/ru/tools/#sdk).
 
 ## Прочие SDK {#sdk}
-* [1С:Предприятие 8](https://github.com/leemuar/yandexmq-sdk-1c)
+* [Клиент ЯндексMQ для 1С:Предприятие 8](https://github.com/leemuar/yandexmq-sdk-1c)
 
 ## Подготовка к работе {#preparations}
 

--- a/ru/message-queue/instruments/index.md
+++ b/ru/message-queue/instruments/index.md
@@ -2,6 +2,9 @@
 
 Для использования [API](../../glossary/rest-api.md) подходят все инструменты, совместимые с Amazon SQS: AWS CLI, Boto3 и другие [поддерживаемые SDK](https://aws.amazon.com/ru/tools/#sdk).
 
+## Прочие SDK {#sdk}
+* [1С:Предприятие 8](https://github.com/leemuar/yandexmq-sdk-1c)
+
 ## Подготовка к работе {#preparations}
 
 1. [Создайте сервисный аккаунт](../../iam/operations/sa/create.md).

--- a/ru/message-queue/instruments/index.md
+++ b/ru/message-queue/instruments/index.md
@@ -3,7 +3,8 @@
 Для использования [API](../../glossary/rest-api.md) подходят все инструменты, совместимые с Amazon SQS: AWS CLI, Boto3 и другие [поддерживаемые SDK](https://aws.amazon.com/ru/tools/#sdk).
 
 ## Прочие SDK {#sdk}
-* [Клиент ЯндексMQ для 1С:Предприятие 8](https://github.com/leemuar/yandexmq-sdk-1c)
+
+* [Клиент ЯндексMQ для 1С:Предприятие 8](https://github.com/leemuar/yandexmq-sdk-1c). Поддерживается сторонними разработчиками.
 
 ## Подготовка к работе {#preparations}
 


### PR DESCRIPTION
Добавил в документацию сервиса ЯндексMQ ссылку на библиотеку для работы с сервисом в среде 1С:Предприятие 8

1С:Предприятие 8 - популярная на территории СНГ ERP система, упоминание библиотеки на странице документации может быть полезно тем кто делает интеграцию сервиса ЯндексMQ с 1С

Библиотека не официальная, на сайте aws ее упоминаний нет, поэтому выношу ее в отдельный раздел

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
- добавил ссылку на библиотеку для работы с ymq из 1С:Предприятие 8