### PR TITLE
fix: autoscaling disk_size_limit unit

### DIFF
--- a/ru/terraform/resources/mdb_kafka_cluster.md
+++ b/ru/terraform/resources/mdb_kafka_cluster.md
@@ -478,7 +478,7 @@ Optional:
 
 Required:
 
-- `disk_size_limit` (Number) Maximum possible size of disk in bytes.
+- `disk_size_limit` (Number) Maximum possible size of disk in gigabytes.
 
 Optional:
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
Несмотря на то, что в документации до этого было указано, что disk_size_autoscaling.disk_size_limit указывается в байтах - на практике провайдер принимает ГБ.

Если указать байты, например 100000000000 для 100 Гб, то при прокатке появится ошибка вида `max disk size value must be more than 0`.

Это скриншот, если в UI создать кластер с макс. размером в 100 гб и попытаться в терраформе указать в байтах.
<img width="560" height="97" alt="image" src="https://github.com/user-attachments/assets/3aaf6acd-2640-44b9-b99d-7b80a13bcffc" />
