### PR TITLE
docs: fix macOS PATH configuration in Packer installation guide

### DIFF
--- a/ru/_tutorials/infrastructure/packer-quickstart.md
+++ b/ru/_tutorials/infrastructure/packer-quickstart.md
@@ -139,7 +139,7 @@ Packer создаст и запустит виртуальную машину с
   1. Добавьте Packer в переменную `PATH`: 
 
       ```bash
-      echo 'export PATH="$PATH:$HOME/<имя_пользователя>/packer"' >> ~/.bash_profile
+      echo 'export PATH="$PATH:$HOME/packer"' >> ~/.bash_profile
       source ~/.bash_profile
       ```
 


### PR DESCRIPTION
## Summary
Fixed incorrect PATH configuration in the macOS installation section of Packer quickstart guide.

## Problem
In the macOS installation instructions (line 142), the PATH export command contained a redundant user directory placeholder that would result in an incorrect path.

Reasoning
$HOME already points to the user's home directory (e.g., /Users/username) Adding /<имя_пользователя> creates an incorrect path like /Users/username/username/packer Correct path should be: /Users/username/packer
This aligns with the Linux installation approach (line 83)

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

my ID on Yandex Cloud: ajei941vku39ckp84m69
