### PR TITLE
Fix formatting of command in agent setup instructions

### DIFF
--- a/ru/_includes/monitoring/agent-setup-deb.md
+++ b/ru/_includes/monitoring/agent-setup-deb.md
@@ -1,9 +1,9 @@
 1. Скачайте последнюю версию deb-пакета:
 
     ```bash
-    ubuntu_name="<версия_ОС>" \
-    ua_version=$(curl --silent https://{{ s3-storage-host }}/yc-unified-agent/latest-version) \
-    bash -c 'curl --silent --remote-name https://{{ s3-storage-host }}/yc-unified-agent/releases/${ua_version}/deb/${ubuntu_name}/yandex-unified-agent_${ua_version}_amd64.deb'
+    ubuntu_name="<версия_ОС>"
+    ua_version=$(curl --silent https://{{ s3-storage-host }}/yc-unified-agent/latest-version)
+    bash -c "curl --silent --remote-name https://{{ s3-storage-host }}/yc-unified-agent/releases/${ua_version}/deb/${ubuntu_name}/yandex-unified-agent_${ua_version}_amd64.deb"
     ```
 
     Где `ubuntu_name` — версия операционной системы:


### PR DESCRIPTION
Однострочник, разнесённый на три строки применять вручную неудобно. А если применять раздельно, то значения переменных в одинарных кавычках не подставляются.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
