### PR TITLE
Fix platform_id for GPU VM in Terraform configuration

### DIFF
--- a/ru/compute/operations/vm-create/create-vm-with-gpu.md
+++ b/ru/compute/operations/vm-create/create-vm-with-gpu.md
@@ -136,7 +136,7 @@ description: Следуя данной инструкции, вы сможете
      resource "yandex_compute_instance" "vm-1" {
        name                      = "vm-with-gpu"
        allow_stopping_for_update = true
-       platform_id               = "standard-v3"
+       platform_id               = "gpu-standard-v3"
        zone                      = "<зона_доступности>"
 
        resources {


### PR DESCRIPTION
  ## Проблема

  В файле `ru/compute/operations/vm-create/create-vm-with-gpu.md` в примере
  Terraform указан `platform_id = "standard-v3"` (строка 139) — это обычная
  платформа без GPU. При этом в примере CLI в том же файле правильно указано
  `--platform=gpu-standard-v3` (строка 55).

  Пользователь, следуя примеру Terraform, получит ошибку `terraform apply`
  (параметр gpus не поддерживается на standard-v3) или создаст ВМ без GPU.

  ## Исправление

  Заменил `platform_id` с `"standard-v3"` на `"gpu-standard-v3"`.