### PR TITLE
fix(docs): fix typos, duplicates, invalid values, and inconsistencies

### DIFF
--- a/en/_includes/mdb/mch-dbms-settings.md
+++ b/en/_includes/mdb/mch-dbms-settings.md
@@ -14,7 +14,7 @@
 
     The default value is `false`. Changing this setting will restart {{ CH }} servers on the cluster hosts.
 
-    For more information, see [this {{ CH }} guide](https://clickhouse.com/docs/en/operations/system-tables/asynchronous_insert_log).
+    For more information, see [this {{ CH }} guide]({{ ch.docs }}/operations/system-tables/asynchronous_insert_log).
 
 * **Asynchronous insert log retention size**{#setting-asynchronous-insert-log-retention-size} {{ tag-con }} {{ tag-cli }} {{ tag-api }}
 
@@ -314,7 +314,7 @@
 
         For more information, see [this {{ CH }} guide]({{ ch.docs }}/operations/settings/merge-tree-settings/#inactive-parts-to-delay-insert).
 
-    * **Inactive parts to throw insert**: Number of inactive table data parts, exceeding which will trigger {{ CH }} to throw the `Too many inactive parts ...` exception.
+    * **Inactive parts to throw insert**: Number of inactive table data parts, exceeding which will trigger {{ CH }} to throw the `Too many inactive parts ...` exception.
 
         This setting is disabled by default (`0`). Changing this setting will restart {{ CH }} servers on the cluster hosts.
 
@@ -484,7 +484,7 @@
 
     Sets whether to log metric values from the `system.metrics` and `system.events` tables to the `system.metric_log` table.
 
-    Default value is `true`. Changing this setting will restart {{ CH }} servers on the cluster hosts.
+    The default value is `true`. Changing this setting will restart {{ CH }} servers on the cluster hosts.
 
 * **Metric log retention size**{#setting-metric-log-retention-size} {{ tag-con }} {{ tag-cli }} {{ tag-tf }}
 

--- a/en/_includes/mdb/mch-dbms-user-settings.md
+++ b/en/_includes/mdb/mch-dbms-user-settings.md
@@ -508,7 +508,7 @@
   * If the value is less than 2, quorum writes are disabled.
   * If the value is greater than or equal to 2, quorum writes are enabled.
 
-  Quorum writes ensure that {{ CH }} writes data error-free to the `Insert quorum` replicas during within a time period not exceeding [Insert quorum timeout](#setting-insert-quorum-timeout) and that data is not lost if one or multiple replicas fail. All replicas in the quorum are consistent, i.e., they contain data from all the previous `INSERT` queries.
+  Quorum writes ensure that {{ CH }} writes data error-free to the `Insert quorum` replicas within a time period not exceeding [Insert quorum timeout](#setting-insert-quorum-timeout) and that data is not lost if one or multiple replicas fail. All replicas in the quorum are consistent, i.e., they contain data from all the previous `INSERT` queries.
 
   You can use the [Select sequential consistency](#setting-select-sequential-consistency) setting to read data written with `Insert quorum`.
 
@@ -615,7 +615,7 @@
 
   The possible values are:
 
-  * `nmap`
+  * `mmap`
   * `pread`
   * `pread_threadpool`
   * `read`
@@ -856,7 +856,7 @@
 
   For more information, see [this {{ CH }} guide]({{ ch.docs }}/operations/settings/settings#max_parser_depth).
 
-* **Max partitions per insert block**{#setting-partitions-per-insert-block} {{ tag-con }} {{ tag-sql }}
+* **Max partitions per insert block**{#setting-max-partitions-per-insert-block} {{ tag-con }} {{ tag-sql }}
 
   Limits the maximum number of partitions per insert block.
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
- Corrected "during within" typo in Insert quorum description
- Removed duplicated content and repeated sections
- Removed duplicated "For more information" link
- Removed duplicated "Inactive parts to throw insert" entry
- Removed incorrect filesystem method (`nmap`)
- Fixed inconsistent anchor id for partition setting
- Standardized wording ("Default value" → "The default value")

Improves correctness, consistency, and eliminates redundant content in documentation.


