### PR TITLE
Fix wget command for config.yaml (use raw URL)

### DIFF
--- a/ru/_tutorials/containers/config-k8s-fluent-bit-logging.md
+++ b/ru/_tutorials/containers/config-k8s-fluent-bit-logging.md
@@ -127,7 +127,7 @@
   1. Скачайте конфигурационный файл `config.yaml`:
 
      ```bash
-     wget https://github.com/yandex-cloud-examples/yc-mk8s-fluent-bit-logging/blob/main/config.yaml
+     wget https://raw.githubusercontent.com/yandex-cloud-examples/yc-mk8s-fluent-bit-logging/main/config.yaml
      ```
 
   1. Укажите идентификатор [созданной ранее](#before-you-begin) лог-группы и опционально идентификатор кластера в секции `[OUTPUT]` файла `config.yaml`:


### PR DESCRIPTION
## Что изменено
Исправлена команда `wget` для скачивания `config.yaml`.

## Почему
Ссылка указывала на страницу GitHub (`/blob/`), из-за чего скачивалась HTML-страница вместо файла.

## Исправление
Использован raw URL (`raw.githubusercontent.com`).
