### PR TITLE
Fix ссылки на документацию prometheus

### DIFF
--- a/ru/monitoring/concepts/data-collection/unified-agent/inputs.md
+++ b/ru/monitoring/concepts/data-collection/unified-agent/inputs.md
@@ -45,7 +45,7 @@
 
         # Формат получаемых сообщений. В настоящий момент поддерживается только значение prometheus.
         format:  # обязательный
-          # Входящие сообщения имеют формат prometheus (https://github.com/prometheus/docs/blob/master/content/docs/instrumenting/exposition_formats.md).
+          # Входящие сообщения имеют формат prometheus (https://github.com/prometheus/docs/blob/main/docs/instrumenting/exposition_formats.md).
           prometheus: {}
         
         metric_name_label:  my_name  # необязательный, позволяет переименовать метку name вашего приложения, поскольку это имя зарезервировано агентом.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
Ссылка была невалидной, исправил на текущую