### PR TITLE
Update install-agent-linux.md on Ubuntu 24.04

### DIFF
--- a/ru/_includes/backup/operations/install-agent-linux.md
+++ b/ru/_includes/backup/operations/install-agent-linux.md
@@ -7,7 +7,8 @@
 
       ```bash
       sudo apt update && \
-      sudo apt install -y jq && \
+      sudo apt install -y jq &&
+      sudo apt install uuid-dev && \
       curl https://{{ s3-storage-host }}/backup-distributions/agent_installer.sh | sudo bash
       ```
 


### PR DESCRIPTION
При подключении к любой ВМ на базе Ubuntu 24.04 из образа YC, выпадает ошибка если не до установить пакет uuid-dev,  добавил команду по установке этого пакета

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
