### PR TITLE
Исправление синтаксиса директив calc в примерах тарифов DataLens

### DIFF
--- a/ru/datalens/pricing-changes.md
+++ b/ru/datalens/pricing-changes.md
@@ -68,7 +68,7 @@ editable: false
 
 12 мая приобрели 5 рабочих мест, а 20 мая — еще 3 рабочих места.
 
-Общая стоимость за май составит (10 + 5 + 3) × {{ sku|RUB|datalens.users.v1|string }} = {% calc [currency=RUB] (10 + 5 + 3) × {{ sku|RUB|datalens.users.v1|number }} %}
+Общая стоимость за май составит (10 + 5 + 3) × {{ sku|RUB|datalens.users.v1|string }} = {% calc [currency=RUB] 18 × {{ sku|RUB|datalens.users.v1|number }} %}
 
 {% endcut %}
 
@@ -120,7 +120,7 @@ editable: false
 
 24 декабря приобрели 10 рабочих мест, 28 декабря — 5 рабочих мест, а 29 декабря — еще 3 рабочих места.
 
-Общая стоимость за декабрь составит (10 + 5 + 3) × ({{ sku|RUB|datalens.users.v1|string }} / 2) × (8 / 31) = {% calc [currency=RUB] (10 + 5 + 3) × ({{ sku|RUB|datalens.users.v1|number }} / 2) × (8 / 31) %}
+Общая стоимость за декабрь составит (10 + 5 + 3) × ({{ sku|RUB|datalens.users.v1|string }} / 2) × (8 / 31) = {% calc [currency=RUB] 18 × {{ sku|RUB|datalens.users.v1|number }} / 2 × 8 / 31 %}
 
 {% endcut %}
 

--- a/ru/datalens/pricing.md
+++ b/ru/datalens/pricing.md
@@ -109,7 +109,7 @@ editable: false
 
 12 мая приобрели 5 рабочих мест, а 20 мая — еще 3 рабочих места.
 
-Общая стоимость за май составит (10 + 5 + 3) × {{ sku|RUB|datalens.users.v1|string }} = {% calc [currency=RUB] (10 + 5 + 3) × {{ sku|RUB|datalens.users.v1|number }} %}
+Общая стоимость за май составит (10 + 5 + 3) × {{ sku|RUB|datalens.users.v1|string }} = {% calc [currency=RUB] 18 × {{ sku|RUB|datalens.users.v1|number }} %}
 
 {% endcut %}
 


### PR DESCRIPTION
## Проблема

Валидация YFM в каждом PR этого репозитория выдает три предупреждения `YFM020 / invalid-yfm-directive` на файлы раздела {{ datalens-name }} (видно, например, в прогонах PR #1118 и #1119):

* `ru/datalens/pricing.md` — пример расчета стоимости за май;
* `ru/datalens/pricing-changes.md` — примеры расчета за май и за декабрь (со скидкой 50%).

Из 933 использований директивы `{% calc %}` в репозитории валидатор отклоняет только эти три. Отличие — скобки, внутри которых **только числовые литералы**: `(10 + 5 + 3)`, `(8 / 31)`. В остальных файлах, проходящих валидацию, скобки в `calc` всегда содержат переменную `{{ sku|... }}` (например, `ru/_pricing_examples/cloud-desktop/rub.md`), а выражения из литералов и переменных записаны цепочкой `×` и `/` без скобок (например, `ru/_pricing/datasphere/kzt-resource.md`, `ru/_pricing_examples/monitoring/rub-example.md`).

## Исправление

Выражения внутри `calc` переписаны эквивалентно, без скобок — только конструкциями, которые уже проходят валидацию в других файлах:

* `(10 + 5 + 3) × {{ sku|...|number }}` → `18 × {{ sku|...|number }}`;
* `(10 + 5 + 3) × ({{ sku|...|number }} / 2) × (8 / 31)` → `18 × {{ sku|...|number }} / 2 × 8 / 31`.

Видимый читателю текст формул (до знака `=`) не менялся. Вычисляемые значения не изменились и совпадают с тем, что сейчас отображается на опубликованных страницах:

* май: 18 × 990 = 17 820 ₽;
* декабрь: 18 × 990 / 2 × 8 / 31 = 2 299,3548387097 ₽.

## Контент-программа

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Идентификатор платежного аккаунта: **dn2nu2gbkvke1unpften**
