### PR TITLE
Clarify empty public IP addresses list in static IP instruction

### DIFF
--- a/ru/_includes/vpc/set-static-ip.md
+++ b/ru/_includes/vpc/set-static-ip.md
@@ -13,6 +13,9 @@
    1. В [консоли управления]({{ link-console-main }}) выберите каталог, в котором находится нужный адрес.
    1. Перейдите в сервис **{{ ui-key.yacloud.iam.folder.dashboard.label_vpc }}**.
    1. На панели слева выберите ![image](../../_assets/console-icons/map-pin.svg) **{{ ui-key.yacloud.vpc.switch_addresses }}**.
+
+      Если в списке нет нужного адреса и отображается сообщение о том, что публичных IP-адресов пока нет, этот адрес нельзя сделать статическим из списка адресов. В этом случае сначала [зарезервируйте статический публичный IP-адрес](../../vpc/operations/get-static-ip.md) или используйте CLI.
+      
    1. Нажмите ![image](../../_assets/console-icons/ellipsis.svg) в строке нужного адреса и выберите **{{ ui-key.yacloud.vpc.addresses.button_action-static }}**.
    1. В открывшемся окне нажмите **{{ ui-key.yacloud.vpc.addresses.popup-confirm_button_static }}**.
 


### PR DESCRIPTION
## Что изменено

Добавлено уточнение для инструкции по переводу динамического публичного IP-адреса в статический.

Если в разделе **Virtual Private Cloud → Публичные IP-адреса** список пустой и пользователь видит сообщение о том, что публичных IP-адресов пока нет, шаг «Нажмите ... в строке нужного адреса» выполнить невозможно.

## Почему это нужно

Сейчас инструкция предполагает, что нужный адрес уже отображается в списке. На практике пользователь может открыть указанный раздел и увидеть только сообщение «У вас пока нет публичных IP-адресов» и кнопку «Зарезервировать публичный IP-адрес». В этом случае в интерфейсе нет строки адреса и нет меню «...», о котором говорится в инструкции.

## CLA

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

## Данные для гранта

Готов предоставить платежный аккаунт и идентификатор облака приватно по запросу.