### PR TITLE
Fixed typo in the kubectl name

### DIFF
--- a/en/_includes/managed-kubernetes/kubectl-install.md
+++ b/en/_includes/managed-kubernetes/kubectl-install.md
@@ -1,1 +1,1 @@
-[Install kubect]({{ k8s-docs }}/tasks/tools/install-kubectl) and [configure it to work with the new cluster](../../managed-kubernetes/operations/connect/index.md#kubectl-connect).
+[Install kubectl]({{ k8s-docs }}/tasks/tools/install-kubectl) and [configure it to work with the new cluster](../../managed-kubernetes/operations/connect/index.md#kubectl-connect).

--- a/en/_tutorials/k8s/k8s-cluster-with-no-internet.md
+++ b/en/_tutorials/k8s/k8s-cluster-with-no-internet.md
@@ -189,7 +189,7 @@ As the {{ managed-k8s-name }} cluster has no internet access, you can only conne
 
 1. [Install the {{ yandex-cloud }} command line interface](../../cli/operations/install-cli.md#interactive) (YC CLI).
 1. [Create a YC CLI profile](../../cli/operations/profile/profile-create.md#create).
-1. [Install kubect]({{ k8s-docs }}/tasks/tools/#kubectl) and [configure it to work with the new cluster](../../managed-kubernetes/operations/connect/index.md#kubectl-connect).
+1. [Install kubectl]({{ k8s-docs }}/tasks/tools/#kubectl) and [configure it to work with the new cluster](../../managed-kubernetes/operations/connect/index.md#kubectl-connect).
 
 ## Check cluster availability {#check}
 

--- a/en/managed-kubernetes/operations/connect/create-static-conf.md
+++ b/en/managed-kubernetes/operations/connect/create-static-conf.md
@@ -21,7 +21,7 @@ To run bash commands, you will need a JSON parser, [jq](https://stedolan.github.
 1. [Create a service account](../../../iam/operations/sa/create.md).
 1. [Create a {{ managed-k8s-name }} cluster](../kubernetes-cluster/kubernetes-cluster-create.md#kubernetes-cluster-create) with any suitable configuration.
 1. [Create a node group](../node-group/node-group-create.md) with any suitable configuration.
-1. [Install kubect]({{ k8s-docs }}/tasks/tools/install-kubectl) and [set it up to work with the new cluster](index.md#kubectl-connect). Add the credentials to the `test.kubeconfig` configuration file using the `--kubeconfig=test.kubeconfig` parameter.
+1. [Install kubectl]({{ k8s-docs }}/tasks/tools/install-kubectl) and [set it up to work with the new cluster](index.md#kubectl-connect). Add the credentials to the `test.kubeconfig` configuration file using the `--kubeconfig=test.kubeconfig` parameter.
 
 ## Get a unique cluster ID {#k8s-id}
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru.

Description of changes:

Fixed a typo in the link name in the Getting started block
