### PR TITLE
Обновил структуру rule_set в примере

### DIFF
--- a/ru/smartwebsecurity/operations/waf-profile-delete.md
+++ b/ru/smartwebsecurity/operations/waf-profile-delete.md
@@ -56,12 +56,18 @@ description: Следуя данной инструкции, вы сможете
         name = "<имя_WAF_профиля>"
 
         # Базовый набор правил
-        core_rule_set {
-          inbound_anomaly_score = 2
-          paranoia_level        = local.waf_paranoia_level
-          rule_set {
-            name    = "OWASP Core Ruleset"
-            version = "4.0.0"
+        rule_set {
+          action     = "DENY"
+          is_enabled = true
+          priority   = 1
+          core_rule_set {
+            inbound_anomaly_score = 2
+            paranoia_level        = local.waf_paranoia_level
+            rule_set {
+              name    = "OWASP Core Ruleset"
+              version = "4.0.0"
+              type    = "CORE"
+            }
           }
         }
 
@@ -96,6 +102,6 @@ description: Следуя данной инструкции, вы сможете
 
 - API {#api}
 
-  Воспользуйтесь методом REST API [delete](../waf/api-ref/WafProfile/delete.md) для ресурса [WafProfile](../waf/api-ref/WafProfile/) или вызовом gRPC API [WafProfile/Delete](../waf/api-ref/grpc/WafProfile/delete.md).
+  Воспользуйтесь методом REST API [delete](../waf/api-ref/WafProfile/delete.md) для ресурса [WafProfile](../waf/api-ref/WafProfile/index.md) или вызовом gRPC API [WafProfile/Delete](../waf/api-ref/grpc/WafProfile/delete.md).
 
 {% endlist %}


### PR DESCRIPTION
В примере блок core_rule_set описан на верхнем уровне ресурса. В справочнике https://yandex.cloud/ru/docs/terraform/resources/sws_waf_profile эта форма помечена как устаревшая и core_rule_set нужно вкладывать в rule_set с полями action, is_enabled и priority, а во вложенном rule_set указывать tyре

Заодно поправил ссылку

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Description of changes:
