### PR TITLE
Добавлены CLI и Terraform в инструкцию по облачной сети API-шлюза

### DIFF
--- a/ru/api-gateway/operations/api-gw-network-add.md
+++ b/ru/api-gateway/operations/api-gw-network-add.md
@@ -20,9 +20,75 @@ description: Следуя данной инструкции, вы сможете
     1. В поле **{{ ui-key.yacloud.vpc.label_network }}** укажите облачную сеть, в которой будет находиться API-шлюз.
     1. Нажмите кнопку **{{ ui-key.yacloud.serverless-functions.gateways.form.button_update-gateway }}**.
 
+- CLI {#cli}
+
+  {% include [cli-install](../../_includes/cli-install.md) %}
+
+  {% include [default-catalogue](../../_includes/default-catalogue.md) %}
+
+  1. Посмотрите описание команды CLI для изменения API-шлюза:
+
+     ```bash
+     {{ yc-serverless }} api-gateway update --help
+     ```
+
+  1. Получите список API-шлюзов в каталоге по умолчанию:
+
+     ```bash
+     {{ yc-serverless }} api-gateway list
+     ```
+
+  1. Укажите облачную сеть для нужного API-шлюза:
+
+     ```bash
+     {{ yc-serverless }} api-gateway update \
+       --id <идентификатор_API-шлюза> \
+       --network-name <имя_облачной_сети>
+     ```
+
+     Где:
+     * `--id` — идентификатор API-шлюза.
+     * `--network-name` — имя облачной сети. Вместо имени можно указать идентификатор сети в параметре `--network-id`.
+
+     Чтобы ограничить набор подсетей, в которых будет размещен API-шлюз, вместо сети укажите подсети в параметрах `--subnet-id` или `--subnet-name`.
+
+- {{ TF }} {#tf}
+
+  {% include [terraform-definition](../../_tutorials/_tutorials_includes/terraform-definition.md) %}
+
+  {% include [terraform-install](../../_includes/terraform-install.md) %}
+
+  1. Откройте файл конфигурации {{ TF }} и добавьте блок `connectivity` в описание ресурса `yandex_api_gateway`:
+
+     ```hcl
+     resource "yandex_api_gateway" "test-api-gateway" {
+       name = "<имя_API-шлюза>"
+       ...
+       connectivity {
+         network_id = "<идентификатор_облачной_сети>"
+       }
+     }
+     ```
+
+     Где `network_id` — идентификатор облачной сети, в которой будет находиться API-шлюз.
+
+     Более подробную информацию о параметрах ресурса `yandex_api_gateway` читайте в [документации провайдера]({{ tf-provider-resources-link }}/api_gateway).
+
+  1. Примените изменения:
+
+     {% include [terraform-validate-plan-apply](../../_tutorials/_tutorials_includes/terraform-validate-plan-apply.md) %}
+
+     Проверить результат можно в [консоли управления]({{ link-console-main }}) или с помощью команды CLI:
+
+     ```bash
+     {{ yc-serverless }} api-gateway get <идентификатор_API-шлюза>
+     ```
+
 - API {#api}
 
   Чтобы указать облачную сеть, в которой будет находиться API-шлюз, воспользуйтесь методом REST API [update](../apigateway/api-ref/ApiGateway/update.md) для ресурса [ApiGateway](../apigateway/api-ref/ApiGateway/index.md) или вызовом gRPC API [ApiGatewayService/Update](../apigateway/api-ref/grpc/ApiGateway/update.md).
+
+  В параметре `updateMask` укажите `connectivity`, а в параметре `connectivity.networkId` — идентификатор облачной сети.
 
 {% endlist %}
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Идентификатор платежного аккаунта: `dn2ujjv4advyulwqk7mp`

Description of changes:

Дополнил страницу [Указать облачную сеть, в которой будет находиться API-шлюз](https://yandex.cloud/ru/docs/api-gateway/operations/api-gw-network-add), файл `ru/api-gateway/operations/api-gw-network-add.md`.