### PR TITLE
Исправлены имена языков в блоках кода

### DIFF
--- a/ru/_includes/smartcaptcha/captcha-validation.md
+++ b/ru/_includes/smartcaptcha/captcha-validation.md
@@ -9,7 +9,7 @@
 
 После проверки токен загружается в элемент `<input type="hidden" name="smart-token" value="<токен>" ...>` на странице пользователя. Например:
 
-```HTML
+```html
 <div id="captcha-container" class="smart-captcha" ...>
     <input type="hidden" name="smart-token" value="dD0xNjYyNDU3NDMzO2k9MmEwMjo2Yjg6YjA4MTpiNTk3OjoxOjFiO0Q9MjVCREY1RDgzMDBERjQ3QjExNkUyMDJDNjJFNEI3Q0Y0QjYzRkRDNzJEMkV********DNjMxODgzMUM0REZBNzI1QUE1QzUwO3U9MTY2MjQ1NzQzMzk5MTEwNjQxNTtoPTg4MWRjMDc2YzE3MjkxNGUwNDgwMTVkYzhl********">
     ...
@@ -105,7 +105,7 @@ secret=<ключ_сервера>&token=<токен>&ip=<IP-адрес_польз
 
 1. Запрос без ключа сервера:
 
-    ```JSON
+    ```json
     {
         "status": "failed",
         "message": "Authentication failed. Secret has not provided."
@@ -114,7 +114,7 @@ secret=<ключ_сервера>&token=<токен>&ip=<IP-адрес_польз
 
 1. Запрос без токена или с поврежденным токеном:
 
-    ```JSON
+    ```json
     {
         "status": "failed",
         "message": "Invalid or expired Token."

--- a/ru/_tutorials/security/encrypt/sdk.md
+++ b/ru/_tutorials/security/encrypt/sdk.md
@@ -139,7 +139,7 @@ SDK {{ yandex-cloud }} наиболее удобен для шифрования
 
 - Java {#java}
 
-    ```Java
+    ```java
     SymmetricCryptoServiceBlockingStub symmetricCryptoService = ServiceFactory.builder()
         .endpoint(endpoint)
         .credentialProvider(credentialProvider)

--- a/ru/_tutorials/serverless/send-emails-aws-sdk-go.md
+++ b/ru/_tutorials/serverless/send-emails-aws-sdk-go.md
@@ -175,7 +175,7 @@
       1. {% include [edit-main-go](../../_includes/postbox/send-emails-aws-sdk/edit-main-go.md) %}
       1. Создайте файл `go.mod` и вставьте в него код:
 
-          ```goalng
+          ```go
           module postbox
 
           go 1.23

--- a/ru/certificate-manager/operations/import/cert-create.md
+++ b/ru/certificate-manager/operations/import/cert-create.md
@@ -20,7 +20,7 @@
 
 - PowerShell {#powershell}
 
-  ```PowerShell
+  ```powershell
   openssl req -x509 -newkey rsa:4096 -nodes `
     -keyout key.pem `
     -out cert.pem `

--- a/ru/managed-mysql/operations/connect/clients.md
+++ b/ru/managed-mysql/operations/connect/clients.md
@@ -54,7 +54,7 @@ sudo apt update && sudo apt install --yes mysql-client
 
 - Подключение с SSL {#with-ssl}
 
-  ```PowerShell
+  ```powershell
   mysqlsh --host=<FQDN_любого_хоста_{{ MY }}> `
           --port={{ port-mmy }} `
           --ssl-ca=<абсолютный_путь_к_файлу_сертификата> `
@@ -67,7 +67,7 @@ sudo apt update && sudo apt install --yes mysql-client
 
 - Подключение без SSL {#without-ssl}
 
-  ```PowerShell
+  ```powershell
   mysqlsh --host=<FQDN_любого_хоста_{{ MY }}> `
           --port={{ port-mmy }} `
           --ssl-mode=DISABLED `


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Идентификатор платежного аккаунта: `dn2ujjv4advyulwqk7mp`

Description of changes:

В восьми блоках кода язык указан не так, как везде в документации, и подсветка синтаксиса не работает. В одном случае опечатка, блок с содержимым `go.mod` помечен как `goalng`. В остальных заглавные буквы вместо строчных, `PowerShell`, `JSON`, `HTML` и `Java`, тогда как в репозитории принято строчное написание. Содержимое блоков не менялось.
