### PR TITLE
Добавлен API в инструкцию по резервированию адреса с защитой от DDoS

### DIFF
--- a/ru/vpc/operations/enable-ddos-protection.md
+++ b/ru/vpc/operations/enable-ddos-protection.md
@@ -69,5 +69,13 @@ description: Следуя данной инструкции, вы сможете
   yc vpc address list
   ```
 
+- API {#api}
+
+  Чтобы зарезервировать защищенный статический IP-адрес, воспользуйтесь методом REST API [create](../api-ref/Address/create.md) для ресурса [Address](../api-ref/Address/index.md) или вызовом gRPC API [AddressService/Create](../api-ref/grpc/Address/create.md) и передайте в запросе:
+
+  * Идентификатор [каталога](../../resource-manager/concepts/resources-hierarchy.md#folder), в котором будет зарезервирован адрес, в параметре `folderId`.
+  * Идентификатор [зоны доступности](../../overview/concepts/geo-scope.md), в которой нужно зарезервировать адрес, в параметре `externalIpv4AddressSpec.zoneId`.
+  * Провайдера защиты от DDoS-атак в параметре `externalIpv4AddressSpec.requirements.ddosProtectionProvider` со значением `qrator`.
+
 {% endlist %}
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Идентификатор платежного аккаунта: `dn2ujjv4advyulwqk7mp`

Description of changes:

В инструкции «Включить защиту от DDoS-атак» (`ru/vpc/operations/enable-ddos-protection.md`) раздел о резервировании защищенного статического IP-адреса описывал только консоль управления и Terraform. Добавлена вкладка **API** — резервирование через REST-метод `create` для ресурса `Address` или gRPC-вызов `AddressService/Create` с перечнем передаваемых параметров: `folderId`, `externalIpv4AddressSpec.zoneId` и `externalIpv4AddressSpec.requirements.ddosProtectionProvider` со значением `qrator`.

Путь поля сверен со [справочником API](https://yandex.cloud/ru/docs/vpc/api-ref/Address/create) (`ExternalIpv4AddressSpec` → `requirements` → `ddosProtectionProvider`). Вкладка CLI не добавлена намеренно: у команды `yc vpc address create` свойство защиты от DDoS в спецификации `--external-ipv4` отсутствует (проверено на Yandex Cloud CLI 1.27.0). Оформление вкладки соответствует соседней инструкции `get-static-ip.md`.